### PR TITLE
Functional Group Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -721,7 +721,14 @@
                 <version>5.1.8</version>
                 <configuration>
                     <instructions>
-                        <Export-Package>org.openscience.*</Export-Package>
+                        <Import-Package>
+                            *;resolution:=optional,
+                            org.slf4j;resolution:=dynamic,
+                            org.apache.logging.log4j;resolution:=dynamic
+                        </Import-Package>
+                        <Export-Package>
+                            *;version="${version}";-noimport:=true,
+                        </Export-Package>
                     </instructions>
                     <noWarningProjectTypes>pom</noWarningProjectTypes>
                 </configuration>

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -110,8 +110,6 @@ import java.util.Queue;
  * multiple ways, e.g. by checking for atomic numbers equal to 0 or checking
  * "instanceof IPseudoAtom".
  * <br/>
- * Note: this implementation is not thread-safe. Each parallel thread
- * should have its own instance of this class.
  *
  * @author Sebastian Fritsch
  * @author Jonas Schaub

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -101,7 +101,7 @@ public class FunctionalGroupsFinder {
     /**
      * Defines the mode for generalizing functional group environments (default), keeping them whole, or only extracting marked atoms.
      */
-    public static enum Mode {
+    public enum Mode {
         /**
          * Default mode including the generalization step.
          */
@@ -136,7 +136,7 @@ public class FunctionalGroupsFinder {
      * Describes one carbon atom in the environment of a marked atom. It can either be aromatic
      * or aliphatic and also contains a clone of its connecting bond.
      */
-    private class EnvironmentalC {
+    private static class EnvironmentalC {
         /**
          * Indicates whether carbon atom is aromatic or aliphatic.
          */
@@ -170,7 +170,7 @@ public class FunctionalGroupsFinder {
          * @param aConnectingBond bond instance connecting to the marked atom
          * @param anIndexInBond index of the atom in the connecting bond
          */
-        public EnvironmentalC(EnvironmentalCType aType, IBond aConnectingBond, int anIndexInBond) {
+        EnvironmentalC(EnvironmentalCType aType, IBond aConnectingBond, int anIndexInBond) {
             this.type = aType;
             this.bondIndex = anIndexInBond;
             this.bondOrder = aConnectingBond.getOrder();
@@ -183,7 +183,7 @@ public class FunctionalGroupsFinder {
          *
          * @return EnvironmentalCType enum constant
          */
-        public EnvironmentalCType getType() {
+        EnvironmentalCType getType() {
             return this.type;
         }
         //
@@ -197,7 +197,7 @@ public class FunctionalGroupsFinder {
          *                   be set via .setIsAromatic(boolean);
          * @return new bond connecting marked FG atom and environment atom in the correct order and with the cached properties
          */
-        public IBond createBond(IAtom aTargetAtom, IAtom anEnvCAtom) {
+        IBond createBond(IAtom aTargetAtom, IAtom anEnvCAtom) {
             IBond tmpBond = aTargetAtom.getBuilder().newInstance(IBond.class);
             if (this.bondIndex == 0) {
                 tmpBond.setAtoms(new IAtom[] {anEnvCAtom, aTargetAtom});
@@ -216,12 +216,12 @@ public class FunctionalGroupsFinder {
      * CDK logging tool instance for this class. Use FunctionalGroupsFinder.LOGGING_TOOL.setLevel(ILoggingTool.DEBUG);
      * to activate debug messages.
      */
-    public static final ILoggingTool LOGGING_TOOL = LoggingToolFactory.createLoggingTool(FunctionalGroupsFinder.class);
+    private static final ILoggingTool LOGGING_TOOL = LoggingToolFactory.createLoggingTool(FunctionalGroupsFinder.class);
     //
     /**
      * Property name for marking carbonyl carbon atoms via IAtom properties.
      */
-    public static final String CARBONYL_C_MARKER = "FGF-Carbonyl-C";
+    private static final String CARBONYL_C_MARKER = "FGF-Carbonyl-C";
     //
     /**
      * Environment mode setting, defining whether environments should be generalized (default) or kept as whole.
@@ -281,8 +281,7 @@ public class FunctionalGroupsFinder {
      * @return new FunctionalGroupsFinder instance that generalizes returned functional groups
      */
     public static FunctionalGroupsFinder newFunctionalGroupsFinderGeneralizingMode() {
-        FunctionalGroupsFinder tmpFGF = new FunctionalGroupsFinder(FunctionalGroupsFinder.Mode.DEFAULT);
-        return tmpFGF;
+        return new FunctionalGroupsFinder(Mode.DEFAULT);
     }
     //
     /**
@@ -292,8 +291,7 @@ public class FunctionalGroupsFinder {
      * @return new FunctionalGroupsFinder instance that does NOT generalize returned functional groups
      */
     public static FunctionalGroupsFinder newFunctionalGroupsFinderFullEnvironmentMode() {
-        FunctionalGroupsFinder tmpFGF = new FunctionalGroupsFinder(FunctionalGroupsFinder.Mode.NO_GENERALIZATION);
-        return tmpFGF;
+        return new FunctionalGroupsFinder(Mode.NO_GENERALIZATION);
     }
     //
     /**
@@ -303,8 +301,7 @@ public class FunctionalGroupsFinder {
      * @return new FunctionalGroupsFinder instance that extracts only marked atoms
      */
     public static FunctionalGroupsFinder newFunctionalGroupsFinderOnlyMarkedAtomsMode() {
-        FunctionalGroupsFinder tmpFGF = new FunctionalGroupsFinder(FunctionalGroupsFinder.Mode.ONLY_MARKED_ATOMS);
-        return tmpFGF;
+        return new FunctionalGroupsFinder(Mode.ONLY_MARKED_ATOMS);
     }
     //
     /**
@@ -436,7 +433,7 @@ public class FunctionalGroupsFinder {
         try {
             EdgeToBondMap tmpBondMap = EdgeToBondMap.withSpaceFor(aMolecule);
             //throws IllegalArgumentException if a bond was found which contained atoms not in the molecule
-            int[][] tmpAdjList = GraphUtil.toAdjList(aMolecule, tmpBondMap);
+            int[][] tmpAdjList = GraphUtil.toAdjList(aMolecule);
             //throws specific IllegalArgumentException if one of the constraints is not met
             FunctionalGroupsFinder.checkConstraints(aMolecule, tmpAdjList);
             return true;
@@ -748,7 +745,7 @@ public class FunctionalGroupsFinder {
         } //markedAtoms is empty now
         // also create FG for lone aromatic heteroatoms, not connected to an FG yet.
         for (int tmpAtomIdx : this.aromaticHeteroAtomIndicesToIsInGroupBoolMapCache.keySet()) {
-            if (!this.aromaticHeteroAtomIndicesToIsInGroupBoolMapCache.get(tmpAtomIdx).booleanValue()) {
+            if (!this.aromaticHeteroAtomIndicesToIsInGroupBoolMapCache.get(tmpAtomIdx)) {
                 tmpFunctionalGroupIdx++;
                 tmpAtomIdxToFGArray[tmpAtomIdx] = tmpFunctionalGroupIdx;
                 if (FunctionalGroupsFinder.isDbg()) {
@@ -1130,7 +1127,7 @@ public class FunctionalGroupsFinder {
         Objects.requireNonNull(aMolecule, "given molecule is null");
         Objects.requireNonNull(anAdjacencyList, "Adjacency list is null");
         for (IAtom tmpAtom : aMolecule.atoms()) {
-            if (tmpAtom.getFormalCharge() != null && tmpAtom.getFormalCharge().intValue() != 0) {
+            if (tmpAtom.getFormalCharge() != null && tmpAtom.getFormalCharge() != 0) {
                 throw new IllegalArgumentException("Input molecule must not contain any formal charges.");
             }
             if (!FunctionalGroupsFinder.isNonmetal(tmpAtom)) {
@@ -1151,17 +1148,16 @@ public class FunctionalGroupsFinder {
      * @param anAtom the atom to test
      * @return true if the given atom is identified as a pseudo (R) atom
      */
-    static boolean isPseudoAtom(IAtom anAtom) {
+    private static boolean isPseudoAtom(IAtom anAtom) {
         Integer tmpAtomicNr = anAtom.getAtomicNumber();
         if (Objects.isNull(tmpAtomicNr)) {
             return true;
         }
         String tmpSymbol = anAtom.getSymbol();
-        return tmpAtomicNr == IAtom.Wildcard
-                || tmpAtomicNr == null
-                || tmpSymbol.equals("R")
-                || tmpSymbol.equals("*")
-                || (anAtom instanceof IPseudoAtom);
+        return tmpAtomicNr == IAtom.Wildcard ||
+                tmpSymbol.equals("R") ||
+                tmpSymbol.equals("*") ||
+                anAtom instanceof IPseudoAtom;
     }
     //
     /**
@@ -1171,12 +1167,12 @@ public class FunctionalGroupsFinder {
      * @param anAtom the atom to test
      * @return true if the given atom is neither a carbon nor a hydrogen or pseudo atom
      */
-    static boolean isHeteroatom(IAtom anAtom) {
+    private static boolean isHeteroatom(IAtom anAtom) {
         Integer tmpAtomicNr = anAtom.getAtomicNumber();
         if (Objects.isNull(tmpAtomicNr)) {
             return false;
         }
-        int tmpAtomicNumberInt = tmpAtomicNr.intValue();
+        int tmpAtomicNumberInt = tmpAtomicNr;
         return tmpAtomicNumberInt != IAtom.H && tmpAtomicNumberInt != IAtom.C
                 && !FunctionalGroupsFinder.isPseudoAtom(anAtom);
     }
@@ -1188,12 +1184,12 @@ public class FunctionalGroupsFinder {
      * @param anAtom atom to check
      * @return true if the given atom is organic and not a metal or metalloid atom
      */
-    static boolean isNonmetal(IAtom anAtom) {
+    private static boolean isNonmetal(IAtom anAtom) {
         Integer tmpAtomicNumber = anAtom.getAtomicNumber();
         if (Objects.isNull(tmpAtomicNumber)) {
             return false;
         }
-        int tmpAtomicNumberInt = tmpAtomicNumber.intValue();
+        int tmpAtomicNumberInt = tmpAtomicNumber;
         return !Elements.isMetal(tmpAtomicNumberInt) && !Elements.isMetalloid(tmpAtomicNumberInt) && !FunctionalGroupsFinder.isPseudoAtom(anAtom);
     }
     //

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -49,25 +49,36 @@ import java.util.Objects;
 import java.util.Queue;
 
 /**
- * Finds and extracts a molecule's functional groups in a purely rule-based manner (it is not a classical functional
- * group identification functionality based on substructure matching!). This class implements Peter Ertl's algorithm for
- * the automated detection and extraction of functional groups in organic molecules
- * (<a href="https://doi.org/10.1186/s13321-017-0225-z">[Ertl P. An algorithm to identify functional groups in organic molecules. J Cheminform. 2017; 9:36.]</a>)
- * and has been described in a scientific publication
- * (<a href="https://doi.org/10.1186/s13321-019-0361-8">[Fritsch, S., Neumann, S., Schaub, J. et al. ErtlFunctionalGroupsFinder: automated rule-based functional group detection with the Chemistry Development Kit (CDK). J Cheminform. 2019; 11:37.]</a>).
- * <br>
- * <br>In brief, the algorithm iterates through all atoms in the input molecule and marks hetero atoms and specific carbon atoms
- * (i.a. those in non-aromatic double or triple bonds etc.) as being part of a functional group. Connected groups of marked
- * atoms are extracted as individual functional groups, together with their unmarked, "environmental" carbon atoms. These
- * environments can be important, e.g. to differentiate an alcohol from a phenol, but are less important in other cases.
- * To account for this, Ertl also devised a "generalization" scheme that generalizes the functional group environments
- * in a way that accounts for their varying significance in different cases. Most environmental atoms are exchanged with
- * pseudo ("R") atoms there. All these functionalities are available in FunctionalGroupsFinder. Additionally, only
- * the marked atoms, completely without their environments, can be extracted.
- * <br>
- * <br>To apply functional group detection to an input molecule, its atom types need to be set and aromaticity needs
- * to be detected beforehand:
- * <blockquote><pre>
+ * Finds and extracts a molecule's functional groups in a purely rule-based
+ * manner (it is not a classical functional group identification functionality
+ * based on substructure matching!). This class implements Peter Ertl's
+ * algorithm for the automated detection and extraction of functional groups in
+ * organic molecules (<a href="https://doi.org/10.1186/s13321-017-0225-z">
+ * [Ertl P. An algorithm to identify functional groups in organic molecules.
+ * J Cheminform. 2017; 9:36.]</a>) and has been described in a scientific
+ * publication (<a href="https://doi.org/10.1186/s13321-019-0361-8">[Fritsch,
+ * S., Neumann, S., Schaub, J. et al. ErtlFunctionalGroupsFinder: automated
+ * rule-based functional group detection with the Chemistry Development Kit
+ * (CDK). J Cheminform. 2019; 11:37.]</a>).
+ * <br/>
+ * In brief, the algorithm iterates through all atoms in the input molecule and
+ * marks hetero atoms and specific carbon atoms (i.a. those in non-aromatic
+ * double or triple bonds etc.) as being part of a functional group. Connected
+ * groups of marked atoms are extracted as individual functional groups,
+ * together with their unmarked, "environmental" carbon atoms. These
+ * environments can be important, e.g. to differentiate an alcohol from a
+ * phenol, but are less important in other cases.
+ * <br/>
+ * To account for this, Ertl also devised a "generalization" scheme that
+ * generalizes the functional group environments in a way that accounts for
+ * their varying significance in different cases. Most environmental atoms are
+ * exchanged with pseudo ("R") atoms there. All these functionalities are
+ * available in FunctionalGroupsFinder. Additionally, only the marked atoms,
+ * completely without their environments, can be extracted.
+ * <br/>
+ * To apply functional group detection to an input molecule, its atom types
+ * need to be set and aromaticity needs to be detected beforehand:
+ * <pre>{@code
  * //Prepare input
  * SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
  * IAtomContainer tmpInputMol = tmpSmiPar.parseSmiles("C[C@@H]1CN(C[C@H](C)N1)C2=C(C(=C3C(=C2F)N(C=C(C3=O)C(=O)O)C4CC4)N)F"); //PubChem CID 5257
@@ -77,29 +88,44 @@ import java.util.Queue;
  * //Identify functional groups
  * FunctionalGroupsFinder tmpFGF = new FunctionalGroupsFinder(); //default: generalization turned on
  * List{@literal <}IAtomContainer{@literal >} tmpFunctionalGroupsList = tmpFGF.extractFunctionalGroups(tmpInputMol);
- * </pre></blockquote>
- * If you want to only identify functional groups in standardised, organic structures, FunctionalGroupsFinder can
- * be configured to only accept molecules that do *not* contain any metal, metalloid, or pseudo (R) atoms or formal charges.
- * Also structures consisting of more than one unconnected component (e.g. ion and counter-ion) are not accepted if(!) the
- * strict input restrictions are turned on (they are turned off by default).
- * This can be done via a boolean parameter in a variant of the central extractFunctionalGroups() method.
- * Please note that structural properties like formal charges and the others mentioned above
- * are not expected to cause issues (exceptions) when processed by this class, but they are not explicitly regarded by
- * the Ertl algorithm and hence this implementation, too. They might therefore cause unexpected behaviour in functional
- * group identification. For example, a formal charge is not listed as a reason to mark a carbon atom and pseudo atoms are simply ignored.
- * <br>To identify molecules that do not fulfill these constraints and should be filtered or preprocessed/standardised,
- * you can use CDK utilities like the ConnectivityChecker class,
- * utility methods in the Elements class, and query IAtom instances for their formal charge. Pseudo atoms can
- * be detected in multiple ways, e.g. by checking for atomic numbers equal to 0 or checking "instanceof IPseudoAtom".
- * <br>
- * <br>Note: this implementation is not thread-safe. Each parallel thread should have its own instance of this class.
+ * }</pre>
+ * If you want to only identify functional groups in standardised, organic
+ * structures, FunctionalGroupsFinder can be configured to only accept molecules
+ * that do *not* contain any metal, metalloid, or pseudo (R) atoms or formal
+ * charges.
+ * <br/>
+ * Also structures consisting of more than one unconnected component (e.g. ion
+ * and counter-ion) are not accepted if(!) the  strict input restrictions are
+ * turned on (they are turned off by default).
+ * This can be done via a boolean parameter in a variant of the central
+ * {@link #extractFunctionalGroups} method.
+ * Please note that structural properties like formal charges and the others 
+ * mentioned above  are not expected to cause issues (exceptions) when processed
+ * by this class, but they are not explicitly regarded by the Ertl algorithm and
+ * hence this implementation, too. They might therefore cause unexpected 
+ * behaviour in functional group identification. For example, a formal charge 
+ * is not listed as a reason to mark a carbon atom and pseudo atoms are simply
+ * ignored.
+ * <br/>
+ * To identify molecules that do not fulfill these constraints and should be 
+ * filtered or preprocessed/standardised, you can use CDK utilities like the 
+ * ConnectivityChecker class, utility methods in the Elements class, and query 
+ * IAtom instances for their formal charge. Pseudo atoms can be detected in 
+ * multiple ways, e.g. by checking for atomic numbers equal to 0 or checking 
+ * "instanceof IPseudoAtom".
+ * <br/>
+ * Note: this implementation is not thread-safe. Each parallel thread 
+ * should have its own instance of this class.
  *
- * @author Sebastian Fritsch, Jonas Schaub
+ * @author Sebastian Fritsch
+ * @author Jonas Schaub
  * @version 1.3
  */
 public class FunctionalGroupsFinder {
+
     /**
-     * Defines the mode for generalizing functional group environments (default), keeping them whole, or only extracting marked atoms.
+     * Defines the mode for generalizing functional group environments 
+     * (default), keeping them whole, or only extracting marked atoms.
      */
     public enum Mode {
         /**
@@ -107,19 +133,21 @@ public class FunctionalGroupsFinder {
          */
         DEFAULT,
         /**
-         * Skips the generalization step. Functional groups will keep their full environment.
+         * Skips the generalization step. Functional groups will keep their
+         * full environment.
          */
         NO_GENERALIZATION,
         /**
-         * Functional groups will only consist of atoms marked according to the conditions defined by Ertl, environments
-         * will be completely ignored.
+         * Functional groups will only consist of atoms marked according to the
+         * conditions defined by Ertl, environments will be completely ignored.
          */
         ONLY_MARKED_ATOMS;
     }
-    //
+    
     /**
-     * Defines whether an environmental carbon atom is aromatic or aliphatic. Only for internal use for caching this
-     * info in the EnvironmentalC instances (see private class below).
+     * Defines whether an environmental carbon atom is aromatic or aliphatic.
+     * Only for internal use for caching this info in the EnvironmentalC
+     * instances (see private class below).
      */
     private static enum EnvironmentalCType {
         /**
@@ -131,40 +159,38 @@ public class FunctionalGroupsFinder {
          */
         C_ALIPHATIC;
     }
-    //
+    
     /**
-     * Describes one carbon atom in the environment of a marked atom. It can either be aromatic
-     * or aliphatic and also contains a clone of its connecting bond.
+     * Describes one carbon atom in the environment of a marked atom. It can
+     * either be aromatic or aliphatic and also contains a clone of its
+     * connecting bond.
      */
     private static class EnvironmentalC {
         /**
          * Indicates whether carbon atom is aromatic or aliphatic.
          */
         private final EnvironmentalCType type;
-        //
-        /**
-         * Bond index of the original C atom.
-         */
+
         private final int bondIndex;
-        //
-        /**
-         * Order of the bond connecting this environmental C atom to the marked functional group atom.
-         */
+
         private final IBond.Order bondOrder;
-        //
+        
         /**
-         * Stereo information of the bond connecting this environmental C atom to the marked functional group atom.
+         * Stereo information of the bond connecting this environmental C
+         * atom to the marked functional group atom.
          */
         private final IBond.Stereo bondStereo;
-        //
+        
         /**
-         * Flags of the bond connecting this environmental C atom to the marked functional group atom. IChemObjecflags
-         * are properties defined by an integer value (array position) and a boolean value.
+         * Flags of the bond connecting this environmental C atom to the marked
+         * functional group atom. IChemObjecflags are properties defined by an
+         * integer value (array position) and a boolean value.
          */
         private final boolean[] bondFlags;
-        //
+        
         /**
-         * Default constructor defining all fields. Order, stereo, and flags are taken from the IBond object directly.
+         * Default constructor defining all fields. Order, stereo, and flags
+         * are taken from the IBond object directly.
          *
          * @param aType aromatic or aliphatic
          * @param aConnectingBond bond instance connecting to the marked atom
@@ -177,25 +203,30 @@ public class FunctionalGroupsFinder {
             this.bondStereo = aConnectingBond.getStereo();
             this.bondFlags = aConnectingBond.getFlags();
         }
-        //
+        
         /**
-         * Returns the type, i.e. whether this carbon atom is aromatic or aliphatic.
+         * Returns the type, i.e. whether this carbon atom is aromatic or
+         * aliphatic.
          *
          * @return EnvironmentalCType enum constant
          */
         EnvironmentalCType getType() {
             return this.type;
         }
-        //
+        
         /**
-         * Method for translating this instance back into a "real" IAtom instance when expanding the functional group
-         * environment, transferring all the cached properties, except the type(!).
+         * Method for translating this instance back into a "real" IAtom
+         * instance when expanding the functional group environment,
+         * transferring all the cached properties, except the type(!).
          *
          * @param aTargetAtom marked functional group atom
-         * @param anEnvCAtom new carbon atom instance that should receive all the cached properties except the type(!);
-         *                   element, atom type "C" and implicit hydrogen count = 0 should be set already; type can later
+         * @param anEnvCAtom new carbon atom instance that should receive all
+         *                   the cached properties except the type(!);
+         *                   element, atom type "C" and implicit hydrogen
+         *                   count = 0 should be set already; type can later
          *                   be set via .setIsAromatic(boolean);
-         * @return new bond connecting marked FG atom and environment atom in the correct order and with the cached properties
+         * @return new bond connecting marked FG atom and environment atom in
+         *         the correct order and with the cached properties
          */
         IBond createBond(IAtom aTargetAtom, IAtom anEnvCAtom) {
             IBond tmpBond = aTargetAtom.getBuilder().newInstance(IBond.class);
@@ -211,155 +242,167 @@ public class FunctionalGroupsFinder {
             return tmpBond;
         }
     }
-    //
-    /**
-     * CDK logging tool instance for this class. Use FunctionalGroupsFinder.LOGGING_TOOL.setLevel(ILoggingTool.DEBUG);
-     * to activate debug messages.
-     */
-    private static final ILoggingTool LOGGING_TOOL = LoggingToolFactory.createLoggingTool(FunctionalGroupsFinder.class);
-    //
+
+    private static final ILoggingTool LOGGER = LoggingToolFactory.createLoggingTool(FunctionalGroupsFinder.class);
+
     /**
      * Property name for marking carbonyl carbon atoms via IAtom properties.
      */
     private static final String CARBONYL_C_MARKER = "FGF-Carbonyl-C";
-    //
+
     /**
-     * Environment mode setting, defining whether environments should be generalized (default) or kept as whole.
+     * Environment mode setting, defining whether environments should be
+     * generalized (default) or kept as whole.
      */
     private Mode envMode;
-    //
+
     /**
      * Map of bonds in the input molecule, cache(!).
      */
     private EdgeToBondMap bondMapCache;
-    //
+
     /**
      * Adjacency list representation of input molecule, cache(!).
      */
     private int[][] adjListCache;
-    //
+
     /**
-     * Set for atoms marked as being part of a functional group, represented by an internal index based on the atom
-     * count in the input molecule, cache(!).
+     * Set for atoms marked as being part of a functional group, represented
+     * by an internal index based on the atom count in the input molecule, cache(!).
      */
     private HashSet<Integer> markedAtomsCache;
-    //
+
     /**
-     * HashMap for storing aromatic hetero-atom indices and whether they have already been assigned to a larger functional
-     * group. If false, they form single-atom FG by themselves, cache(!).
+     * HashMap for storing aromatic hetero-atom indices and whether they have
+     * already been assigned to a larger functional group. If false, they form
+     * single-atom FG by themselves, cache(!).
      * key: atom idx, value: isInGroup
      */
     private HashMap<Integer, Boolean> aromaticHeteroAtomIndicesToIsInGroupBoolMapCache;
-    //
+
     /**
-     * HashMap for storing marked atom to connected environmental carbon atom relations, cache(!).
+     * HashMap for storing marked atom to connected environmental carbon atom
+     * relations, cache(!).
      */
     private HashMap<IAtom, List<EnvironmentalC>> markedAtomToConnectedEnvCMapCache;
-    //
+
     /**
-     * Default constructor for FunctionalGroupsFinder with functional group generalization turned ON.
+     * Default constructor for FunctionalGroupsFinder with functional group
+     * generalization turned ON.
      */
     public FunctionalGroupsFinder() {
         this(Mode.DEFAULT);
     }
-    //
+
     /**
-     * Constructor for FunctionalGroupsFinder that allows setting the treatment of environments in the identified
-     * functional groups. Default: environments will be generalized; no generalization: environments will be kept as whole;
-     * only marked atoms: no environmental atoms whatsoever will be attached to the extracted functional groups.
+     * Constructor for FunctionalGroupsFinder that allows setting the treatment
+     * of environments in the identified functional groups.
      *
-     * @param anEnvMode mode for treating functional group environments (see {@link FunctionalGroupsFinder.Mode}).
+     * @param anEnvMode mode for treating functional group environments
      */
     public FunctionalGroupsFinder(Mode anEnvMode) {
         Objects.requireNonNull(anEnvMode, "Given environment mode cannot be null.");
         this.envMode = anEnvMode;
     }
-    //
+
     /**
-     * Constructs a new FunctionalGroupsFinder instance with generalization of returned functional groups turned ON.
+     * Constructs a new FunctionalGroupsFinder instance with generalization
+     * of returned functional groups turned ON.
      *
-     * @return new FunctionalGroupsFinder instance that generalizes returned functional groups
+     * @return new FunctionalGroupsFinder instance that generalizes returned
+     *         functional groups
      */
     public static FunctionalGroupsFinder newFunctionalGroupsFinderGeneralizingMode() {
         return new FunctionalGroupsFinder(Mode.DEFAULT);
     }
-    //
+
     /**
-     * Constructs a new FunctionalGroupsFinder instance with generalization of returned functional groups turned OFF.
+     * Constructs a new FunctionalGroupsFinder instance with generalization of
+     * returned functional groups turned OFF.
      * The FG will have their full environments.
      *
-     * @return new FunctionalGroupsFinder instance that does NOT generalize returned functional groups
+     * @return new FunctionalGroupsFinder instance that does NOT generalize
+     *         returned functional groups
      */
     public static FunctionalGroupsFinder newFunctionalGroupsFinderFullEnvironmentMode() {
         return new FunctionalGroupsFinder(Mode.NO_GENERALIZATION);
     }
-    //
+
     /**
-     * Constructs a new FunctionalGroupsFinder instance that extracts only the marked atoms of the functional groups,
-     * no attached environmental atoms.
+     * Constructs a new FunctionalGroupsFinder instance that extracts only the
+     * marked atoms of the functional groups, no attached environmental atoms.
      *
-     * @return new FunctionalGroupsFinder instance that extracts only marked atoms
+     * @return new FunctionalGroupsFinder instance that extracts only marked
+     *         atoms
      */
     public static FunctionalGroupsFinder newFunctionalGroupsFinderOnlyMarkedAtomsMode() {
         return new FunctionalGroupsFinder(Mode.ONLY_MARKED_ATOMS);
     }
-    //
+
     /**
-     * Allows setting the treatment of functional group environments after extraction. Default: environments will be
-     * generalized; no generalization: environments will be kept as whole; only marked atoms: no environmental atoms
-     * whatsoever will be attached to the extracted functional groups.
+     * Allows setting the treatment of functional group environments after
+     * extraction.
      *
-     * @param anEnvMode mode for treating functional group environments (see {@link FunctionalGroupsFinder.Mode}).
+     * @param anEnvMode mode for treating functional group environments
      */
     public void setEnvMode(Mode anEnvMode) {
         Objects.requireNonNull(anEnvMode, "Given environment mode cannot be null.");
         this.envMode = anEnvMode;
     }
-    //
+
     /**
-     * Returns the current setting for the treatment of functional group environments after extraction.
+     * Returns the current setting for the treatment of functional group
+     * environments after extraction.
      *
      * @return currently set environment mode
      */
     public Mode getEnvMode() {
         return this.envMode;
     }
-    //
+
     /**
-     * Find all functional groups in a molecule. The input atom container instance is cloned before processing to leave
-     * the input container intact. The strict input restrictions (no charged atoms, pseudo atoms, metals, metalloids or
-     * unconnected components) do not apply by default. They can be turned on again in another variant of
-     * this method below.
+     * Find all functional groups in a molecule. The input atom container
+     * instance is cloned before processing to leave the input container intact.
+     * The strict input restrictions (no charged atoms, pseudo atoms, metals,
+     * metalloids or unconnected components) do not apply by default. They can
+     * be turned on again in another variant of this method below.
      *
      * @param aMolecule the molecule to identify functional groups in
      * @throws CloneNotSupportedException if cloning is not possible
-     * @throws IllegalArgumentException if the input molecule was not preprocessed correctly, i.e. implicit hydrogen
-     *                                  counts are unset
+     * @throws IllegalArgumentException if the input molecule was not
+     *                                  preprocessed correctly, i.e. implicit
+     *                                  hydrogen counts are unset
      * @return a list with all functional groups found in the molecule
      */
     public List<IAtomContainer> extractFunctionalGroups(IAtomContainer aMolecule) throws CloneNotSupportedException, IllegalArgumentException {
         return this.extractFunctionalGroups(aMolecule, true, false);
     }
-    //
+
     /**
      * Find all functional groups in a molecule.
-     * The strict input restrictions (no charged atoms, pseudo atoms, metals, metalloids or unconnected components) do not apply by
-     * default. They can be turned on again in another variant of this method below.
+     * The strict input restrictions (no charged atoms, pseudo atoms, metals,
+     * metalloids or unconnected components) do not apply by default. They can
+     * be turned on again in another variant of this method below.
      *
      * @param aMolecule the molecule to identify functional groups in
-     * @param aShouldInputBeCloned use 'false' to reuse the input container's bonds and atoms in the extraction of the functional
-     *                             groups; this may speed up the extraction and lower the memory consumption for processing large
-     *                             amounts of data but corrupts the original input container; use 'true' to work with a clone and
-     *                             leave the input container intact
+     * @param aShouldInputBeCloned use 'false' to reuse the input container's
+     *                             bonds and atoms in the extraction of the
+     *                             functional groups; this may speed up the
+     *                             extraction and lower the memory consumption
+     *                             for processing large amounts of data but
+     *                             corrupts the original input container; use
+     *                             'true' to work with a clone and leave the
+     *                             input container intact
      * @throws CloneNotSupportedException if cloning is not possible
-     * @throws IllegalArgumentException if the input molecule was not preprocessed correctly, i.e. implicit hydrogen
-     *                                  counts are unset
+     * @throws IllegalArgumentException if the input molecule was not
+     *                                  preprocessed correctly,
+     *                                  i.e. implicit hydrogen counts are unset
      * @return a list with all functional groups found in the molecule
      */
     public List<IAtomContainer> extractFunctionalGroups(IAtomContainer aMolecule, boolean aShouldInputBeCloned) throws CloneNotSupportedException, IllegalArgumentException {
         return this.extractFunctionalGroups(aMolecule, aShouldInputBeCloned, false);
     }
-    //
+
     /**
      * Find all functional groups in a molecule.
      *
@@ -414,18 +457,23 @@ public class FunctionalGroupsFinder {
         this.clearCache();
         return tmpFunctionalGroupsList;
     }
-    //
+
     /**
-     * Checks whether the given molecule represented by an atom container can be passed on to the
-     * FunctionalGroupsFinder.extractFunctionalGroups() method without problems even if(!) the strict input
-     * restrictions are turned on (turned off by default).
-     * <br>This method will return false if the molecule contains any metal, metalloid, pseudo, or
-     * charged atoms or consists of multiple unconnected parts ('ConnectivityChecker.isConnected(aMolecule)'
-     * must be 'true'). Some of these issues can be solved by respective standardisation routines.
+     * Checks whether the given molecule represented by an atom container can be
+     * passed on to the FunctionalGroupsFinder.extractFunctionalGroups() method
+     * without problems even if(!) the strict input restrictions are turned on
+     * (turned off by default).
+     * <br>This method will return false if the molecule contains any metal,
+     * metalloid, pseudo, or charged atoms or consists of multiple unconnected
+     * parts ('ConnectivityChecker.isConnected(aMolecule)' must be 'true').
+     * Some of these issues can be solved by respective standardisation
+     * routines.
      *
      * @param aMolecule the molecule to check
-     * @return true if the given molecule is a valid parameter for FunctionalGroupsFinder.extractFunctionalGroups()
-     *         method if(!) the input restrictions are turned on (turned off by default)
+     * @return true if the given molecule is a valid parameter for
+     *         FunctionalGroupsFinder.extractFunctionalGroups()
+     *         method if(!) the input restrictions are turned on (turned off
+     *         by default)
      * @throws NullPointerException if parameter is 'null'
      */
     public static boolean isValidInputMoleculeIfRestrictionsAreTurnedOn(IAtomContainer aMolecule) throws NullPointerException {
@@ -441,7 +489,7 @@ public class FunctionalGroupsFinder {
             return false;
         }
     }
-    //
+
     /**
      * Mark all atoms and store them in a set for further processing.
      *
@@ -449,7 +497,7 @@ public class FunctionalGroupsFinder {
      */
     private void markAtoms(IAtomContainer aMolecule) {
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug("########## Starting search for atoms to mark ... ##########");
+            FunctionalGroupsFinder.LOGGER.debug("########## Starting search for atoms to mark ... ##########");
         }
         // store marked atoms
         this.markedAtomsCache = new HashSet<>((int) ((aMolecule.getAtomCount() / 0.75f) + 2), 0.75f);
@@ -487,7 +535,7 @@ public class FunctionalGroupsFinder {
                         // set the *connected* atom as marked (add() true if this set did not already contain the specified element)
                         if (this.markedAtomsCache.add(tmpConnectedIdx)) {
                             if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                FunctionalGroupsFinder.LOGGER.debug(String.format(
                                         "Marking Atom #%d (%s) - Met condition %s",
                                         tmpConnectedIdx,
                                         tmpConnectedAtom.getSymbol(),
@@ -497,7 +545,7 @@ public class FunctionalGroupsFinder {
                         // set the *current* atom as marked and break out of connected atoms
                         tmpIsMarked = true;
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                            FunctionalGroupsFinder.LOGGER.debug(String.format(
                                     "Marking Atom #%d (%s) - Met condition 2.1/2.2",
                                     idx,
                                     tmpAtom.getSymbol()));
@@ -508,7 +556,7 @@ public class FunctionalGroupsFinder {
                                 && this.adjListCache[idx].length == 3) {
                             tmpAtom.setProperty(CARBONYL_C_MARKER, true);
                             if (FunctionalGroupsFinder.isDbg())  {
-                                FunctionalGroupsFinder.LOGGING_TOOL.debug("- was flagged as Carbonly-C");
+                                FunctionalGroupsFinder.LOGGER.debug("- was flagged as Carbonly-C");
                             }
                         }
                         // break out of connected atoms
@@ -523,7 +571,7 @@ public class FunctionalGroupsFinder {
                             // set the connected O/N/S atom as marked
                             this.markedAtomsCache.add(tmpConnectedIdx);
                             if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                FunctionalGroupsFinder.LOGGER.debug(String.format(
                                         "Marking Atom #%d (%s) - Met condition 1",
                                         tmpConnectedIdx,
                                         tmpConnectedAtom.getSymbol()));
@@ -543,7 +591,7 @@ public class FunctionalGroupsFinder {
                                     // set as marked and break out of connected atoms
                                     tmpIsMarked = true;
                                     if (FunctionalGroupsFinder.isDbg()) {
-                                        FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                        FunctionalGroupsFinder.LOGGER.debug(String.format(
                                                 "Marking Atom #%d (%s) - Met condition 2.3",
                                                 idx,
                                                 tmpAtom.getSymbol()));
@@ -563,11 +611,11 @@ public class FunctionalGroupsFinder {
                                         this.markedAtomsCache.add(tmpConnectedInSphere2Idx);
                                         this.markedAtomsCache.add(tmpConnectedInSphere3Idx);
                                         if (FunctionalGroupsFinder.isDbg()) {
-                                            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                            FunctionalGroupsFinder.LOGGER.debug(String.format(
                                                     "Marking Atom #%d (%s) - Met condition 2.4",
                                                     tmpConnectedInSphere2Idx,
                                                     tmpConnectedInSphere2Atom.getSymbol()));
-                                            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                            FunctionalGroupsFinder.LOGGER.debug(String.format(
                                                     "Marking Atom #%d (%s) - Met condition 2.4",
                                                     tmpConnectedInSphere3Idx,
                                                     tmpConnectedInSphere3Atom.getSymbol()));
@@ -575,7 +623,7 @@ public class FunctionalGroupsFinder {
                                         // set current atom as marked and break out of connected atoms
                                         tmpIsMarked = true;
                                         if (FunctionalGroupsFinder.isDbg()) {
-                                            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                            FunctionalGroupsFinder.LOGGER.debug(String.format(
                                                     "Marking Atom #%d (%s) - Met condition 2.4",
                                                     idx,
                                                     tmpAtom.getSymbol()));
@@ -613,7 +661,7 @@ public class FunctionalGroupsFinder {
                 // if heteroatom... (CONDITION 1)
                 this.markedAtomsCache.add(idx);
                 if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                    FunctionalGroupsFinder.LOGGER.debug(String.format(
                             "Marking Atom #%d (%s) - Met condition 1",
                             idx,
                             tmpAtom.getSymbol()));
@@ -625,23 +673,25 @@ public class FunctionalGroupsFinder {
             }
         } //end of for loop that iterates over all atoms in the mol
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+            FunctionalGroupsFinder.LOGGER.debug(String.format(
                     "########## End of search. Marked %d/%d atoms. ##########",
                     this.markedAtomsCache.size(),
                     aMolecule.getAtomCount()));
         }
     }
-    //
+
     /**
-     * Searches the molecule for groups of connected marked atoms and extracts each as a new functional group.
-     * The extraction process includes marked atoms' "environments". Connected H's are captured implicitly.
+     * Searches the molecule for groups of connected marked atoms and extracts
+     * each as a new functional group. The extraction process includes marked
+     * atoms' "environments". Connected H's are captured implicitly.
      *
      * @param aMolecule the molecule which contains the functional groups
-     * @return a list of all functional groups (including "environments") extracted from the molecule
+     * @return a list of all functional groups (including "environments")
+     *         extracted from the molecule
      */
     private List<IAtomContainer> extractGroups(IAtomContainer aMolecule) {
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug("########## Starting identification & extraction of functional groups... ##########");
+            FunctionalGroupsFinder.LOGGER.debug("########## Starting identification & extraction of functional groups... ##########");
         }
         this.markedAtomToConnectedEnvCMapCache = new HashMap<>((int) ((aMolecule.getAtomCount() / 0.75f) + 2), 0.75f);
         int[] tmpAtomIdxToFGArray = new int[aMolecule.getAtomCount()];
@@ -653,7 +703,7 @@ public class FunctionalGroupsFinder {
             // get next markedAtom as the starting node for the search
             int tmpBeginIdx = this.markedAtomsCache.iterator().next();
             if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                FunctionalGroupsFinder.LOGGER.debug(String.format(
                         "Searching new functional group from atom #%d (%s)...",
                         tmpBeginIdx,
                         aMolecule.getAtom(tmpBeginIdx).getSymbol()));
@@ -670,9 +720,9 @@ public class FunctionalGroupsFinder {
                 // if it isn't...
                 IAtom tmpCurrentAtom = aMolecule.getAtom(tmpCurrentQueueIdx);
                 if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format("\tvisiting marked atom: #%d (%s)",
-                            tmpCurrentQueueIdx,
-                            tmpCurrentAtom.getSymbol()));
+                    FunctionalGroupsFinder.LOGGER.debug(String.format("\tvisiting marked atom: #%d (%s)",
+                                                                      tmpCurrentQueueIdx,
+                                                                      tmpCurrentAtom.getSymbol()));
                 }
                 // add its index to the functional group
                 tmpAtomIdxToFGArray[tmpCurrentQueueIdx] = tmpFunctionalGroupIdx;
@@ -697,7 +747,7 @@ public class FunctionalGroupsFinder {
                         // note that this aromatic heteroatom has been added to a group
                         this.aromaticHeteroAtomIndicesToIsInGroupBoolMapCache.put(tmpConnectedIdx, true);
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug("\t\tadded connected aromatic heteroatom "
+                            FunctionalGroupsFinder.LOGGER.debug("\t\tadded connected aromatic heteroatom "
                                     + tmpConnectedAtom.getSymbol());
                         }
                     }
@@ -732,7 +782,7 @@ public class FunctionalGroupsFinder {
                             tmpCAliphCount++;
                         }
                     }
-                    FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                    FunctionalGroupsFinder.LOGGER.debug(String.format(
                             "\t\tlogged marked atom's environment: C_ar:%d, C_al:%d (and %d implicit hydrogens)",
                             tmpCAromCount,
                             tmpCAliphCount,
@@ -740,7 +790,7 @@ public class FunctionalGroupsFinder {
                 }
             } // end of BFS
             if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug("\tsearch completed.");
+                FunctionalGroupsFinder.LOGGER.debug("\tsearch completed.");
             }
         } //markedAtoms is empty now
         // also create FG for lone aromatic heteroatoms, not connected to an FG yet.
@@ -749,33 +799,34 @@ public class FunctionalGroupsFinder {
                 tmpFunctionalGroupIdx++;
                 tmpAtomIdxToFGArray[tmpAtomIdx] = tmpFunctionalGroupIdx;
                 if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGING_TOOL.debug("Created FG for lone aromatic heteroatom: "
+                    FunctionalGroupsFinder.LOGGER.debug("Created FG for lone aromatic heteroatom: "
                             + aMolecule.getAtom(tmpAtomIdx).getSymbol());
                 }
             }
         }
         List<IAtomContainer> tmpFunctionalGroupsList = this.partitionIntoGroups(aMolecule, tmpAtomIdxToFGArray, tmpFunctionalGroupIdx + 1);
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format("########## Found & extracted %d functional groups. ##########",
-                    tmpFunctionalGroupIdx + 1));
+            FunctionalGroupsFinder.LOGGER.debug(String.format("########## Found & extracted %d functional groups. ##########",
+                                                              tmpFunctionalGroupIdx + 1));
         }
         return tmpFunctionalGroupsList;
     }
-    //
+
     /**
-     * Generalizes the full environments of functional groups, according to the Ertl generalization algorithm, providing
-     * a good balance between preserving meaningful detail and generalization.
+     * Generalizes the full environments of functional groups, according to the
+     * Ertl generalization algorithm, providing a good balance between
+     * preserving meaningful detail and generalization.
      *
      * @param aFunctionalGroupsList the list of functional groups including "environments"
      */
     private void expandGeneralizedEnvironments(List<IAtomContainer> aFunctionalGroupsList) {
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug("########## Starting generalization of functional groups... ##########");
+            FunctionalGroupsFinder.LOGGER.debug("########## Starting generalization of functional groups... ##########");
         }
         for (IAtomContainer tmpFunctionalGroup : aFunctionalGroupsList) {
             int tmpAtomCount = tmpFunctionalGroup.getAtomCount();
             if(FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format("Generalizing functional group (%d atoms)...", tmpAtomCount));
+                FunctionalGroupsFinder.LOGGER.debug(String.format("Generalizing functional group (%d atoms)...", tmpAtomCount));
             }
             // pre-checking for special cases...
             if (tmpFunctionalGroup.getAtomCount() == 1) {
@@ -788,7 +839,7 @@ public class FunctionalGroupsFinder {
                     if ((tmpAtom.getAtomicNumber() == IAtom.O && tmpEnvCCount == 1)
                             || (tmpAtom.getAtomicNumber() == IAtom.N && tmpEnvCCount == 1)) {
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                            FunctionalGroupsFinder.LOGGER.debug(String.format(
                                     "\t- found single atomic %s FG with one env. C. Expanding environment...",
                                     tmpAtom.getSymbol()));
                         }
@@ -796,7 +847,7 @@ public class FunctionalGroupsFinder {
                         int tmpAtomImplicitHydrogenCount = tmpAtom.getImplicitHydrogenCount();
                         if (tmpAtomImplicitHydrogenCount != 0) {
                             if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                                FunctionalGroupsFinder.LOGGER.debug(String.format(
                                         "\t- adding %d hydrogens...", tmpAtomImplicitHydrogenCount));
                             }
                             this.addHydrogens(tmpAtom, tmpAtomImplicitHydrogenCount, tmpFunctionalGroup);
@@ -808,19 +859,19 @@ public class FunctionalGroupsFinder {
                     if ((tmpAtom.getAtomicNumber() == IAtom.N && tmpEnvCCount == 2)
                             || (tmpAtom.getAtomicNumber() == IAtom.S && tmpEnvCCount == 1)) {
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug("\t- found sec. amine or simple thiol");
+                            FunctionalGroupsFinder.LOGGER.debug("\t- found sec. amine or simple thiol");
                         }
                         int tmpAtomImplicitHydrogenCount = tmpAtom.getImplicitHydrogenCount();
                         if (tmpAtomImplicitHydrogenCount != 0) {
                             if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format("\t- adding %d hydrogens...",
-                                        tmpAtomImplicitHydrogenCount));
+                                FunctionalGroupsFinder.LOGGER.debug(String.format("\t- adding %d hydrogens...",
+                                                                                  tmpAtomImplicitHydrogenCount));
                             }
                             this.addHydrogens(tmpAtom, tmpAtomImplicitHydrogenCount, tmpFunctionalGroup);
                             tmpAtom.setImplicitHydrogenCount(0);
                         }
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug("\t- expanding environment...");
+                            FunctionalGroupsFinder.LOGGER.debug("\t- expanding environment...");
                         }
                         this.expandEnvironmentGeneralized(tmpAtom, tmpFunctionalGroup);
                         continue;
@@ -834,7 +885,7 @@ public class FunctionalGroupsFinder {
                     }
                     String tmpAtomTypeName = tmpAtom.getAtomTypeName();
                     if (FunctionalGroupsFinder.isDbg()) {
-                        FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                        FunctionalGroupsFinder.LOGGER.debug(String.format(
                                 "\t- found single aromatic heteroatom (%s, Atomtype %s). Adding %d R-Atoms...",
                                 tmpAtom.getSymbol(),
                                 tmpAtomTypeName,
@@ -856,7 +907,7 @@ public class FunctionalGroupsFinder {
                     }
                     int tmpRAtomCount = tmpFunctionalGroupAtom.getValency() - 1;
                     if (FunctionalGroupsFinder.isDbg()) {
-                        FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                        FunctionalGroupsFinder.LOGGER.debug(String.format(
                                 "\t- found connected aromatic heteroatom (%s). Adding %d R-Atoms...",
                                 tmpFunctionalGroupAtom.getSymbol(),
                                 tmpRAtomCount));
@@ -870,20 +921,20 @@ public class FunctionalGroupsFinder {
                             tmpFunctionalGroupAtom.setImplicitHydrogenCount(0);
                         }
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug("\t- ignoring environment for marked carbon atom");
+                            FunctionalGroupsFinder.LOGGER.debug("\t- ignoring environment for marked carbon atom");
                         }
                         continue;
                     } else {
                         if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGING_TOOL.debug("\t- found carbonyl-carbon. Expanding environment...");
+                            FunctionalGroupsFinder.LOGGER.debug("\t- found carbonyl-carbon. Expanding environment...");
                         }
                         this.expandEnvironmentGeneralized(tmpFunctionalGroupAtom, tmpFunctionalGroup);
                         continue;
                     }
                 } else { // processing heteroatoms...
                     if (FunctionalGroupsFinder.isDbg()) {
-                        FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format("\t- found heteroatom (%s). Expanding environment...",
-                                tmpFunctionalGroupAtom.getSymbol()));
+                        FunctionalGroupsFinder.LOGGER.debug(String.format("\t- found heteroatom (%s). Expanding environment...",
+                                                                          tmpFunctionalGroupAtom.getSymbol()));
                     }
                     this.expandEnvironmentGeneralized(tmpFunctionalGroupAtom, tmpFunctionalGroup);
                     continue;
@@ -891,36 +942,38 @@ public class FunctionalGroupsFinder {
             }
         } //end of loop over given functional groups list
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug("########## Generalization of functional groups completed. ##########");
+            FunctionalGroupsFinder.LOGGER.debug("########## Generalization of functional groups completed. ##########");
         }
     }
-    //
+
     /**
-     * Expands the full environments of functional groups, converted into atoms and bonds.
+     * Expands the full environments of functional groups, converted into atoms
+     * and bonds.
      *
-     * @param aFunctionalGroupsList the list of functional groups including their "environments"
+     * @param aFunctionalGroupsList the list of functional groups including
+     *                              their "environments"
      */
     private void expandFullEnvironments(List<IAtomContainer> aFunctionalGroupsList) {
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug("########## Starting expansion of full environments for functional groups... ##########");
+            FunctionalGroupsFinder.LOGGER.debug("########## Starting expansion of full environments for functional groups... ##########");
         }
         for (IAtomContainer tmpFunctionalGroup : aFunctionalGroupsList) {
             int tmpAtomCount = tmpFunctionalGroup.getAtomCount();
             if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                FunctionalGroupsFinder.LOGGER.debug(String.format(
                         "Expanding environment on functional group (%d atoms)...", tmpAtomCount));
             }
             for (int i = 0; i < tmpAtomCount; i++) {
                 IAtom tmpFunctionalGroupAtom = tmpFunctionalGroup.getAtom(i);
                 if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                    FunctionalGroupsFinder.LOGGER.debug(String.format(
                             " - Atom #%d   - Expanding environment...", i));
                 }
                 this.expandEnvironment(tmpFunctionalGroupAtom, tmpFunctionalGroup);
                 int tmpImplicitHydrogenCount = tmpFunctionalGroupAtom.getImplicitHydrogenCount();
                 if (tmpImplicitHydrogenCount != 0) {
                     if (FunctionalGroupsFinder.isDbg()) {
-                        FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+                        FunctionalGroupsFinder.LOGGER.debug(String.format(
                                 "\t- adding %d hydrogens...", tmpImplicitHydrogenCount));
                     }
                     this.addHydrogens(tmpFunctionalGroupAtom, tmpImplicitHydrogenCount, tmpFunctionalGroup);
@@ -929,13 +982,14 @@ public class FunctionalGroupsFinder {
             }
         }
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug("########## Expansion of full environments for functional groups completed. ##########");
+            FunctionalGroupsFinder.LOGGER.debug("########## Expansion of full environments for functional groups completed. ##########");
         }
     }
-    //
+
     /**
-     * Expand the environment of one atom in a functional group. Takes all environmental C atoms cached earlier and
-     * re-adds them to the atom as environment.
+     * Expand the environment of one atom in a functional group. Takes all
+     * environmental C atoms cached earlier and re-adds them to the atom as
+     * environment.
      *
      * @param aFunctionalGroupAtom the atom whose environment to expand
      * @param aFunctionalGroup the functional group container that the atom is part of
@@ -945,7 +999,7 @@ public class FunctionalGroupsFinder {
 
         if (Objects.isNull(tmpEnvCAtomsList) || tmpEnvCAtomsList.isEmpty()) {
             if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug("\t\tfound no environment to expand.");
+                FunctionalGroupsFinder.LOGGER.debug("\t\tfound no environment to expand.");
             }
             return;
         }
@@ -966,17 +1020,18 @@ public class FunctionalGroupsFinder {
             aFunctionalGroup.addBond(tmpBond);
         }
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+            FunctionalGroupsFinder.LOGGER.debug(String.format(
                     "\t\texpanded environment: %dx C_ar and %dx C_al",
                     tmpAromaticCAtomCount,
                     tmpAliphaticCAtomCount));
         }
     }
-    //
+
     /**
-     * Expand the generalized environment of marked heteroatoms and carbonyl-Cs in a functional group.
-     * Takes all environmental C atoms cached earlier and re-adds them to the atom as environment.
-     * Note: only call this on marked heteroatoms / carbonyl-C's!
+     * Expand the generalized environment of marked heteroatoms and carbonyl-Cs
+     * in a functional group. Takes all environmental C atoms cached earlier
+     * and re-adds them to the atom as environment. Note: only call this on
+     * marked heteroatoms / carbonyl-C's!
      *
      * @param aFunctionalGroupAtom the atom whose environment to expand
      * @param aFunctionalGroup the functional group container that the atom is part of
@@ -985,7 +1040,7 @@ public class FunctionalGroupsFinder {
         List<EnvironmentalC> tmpEnvironment = this.markedAtomToConnectedEnvCMapCache.get(aFunctionalGroupAtom);
         if (Objects.isNull(tmpEnvironment)) {
             if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug("\t\tfound no environment to expand.");
+                FunctionalGroupsFinder.LOGGER.debug("\t\tfound no environment to expand.");
             }
             return;
         }
@@ -995,7 +1050,7 @@ public class FunctionalGroupsFinder {
             this.addHydrogens(aFunctionalGroupAtom, 1, aFunctionalGroup);
             aFunctionalGroupAtom.setImplicitHydrogenCount(0);
             if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGING_TOOL.debug("\t\texpanded hydrogen on connected OH-Group");
+                FunctionalGroupsFinder.LOGGER.debug("\t\texpanded hydrogen on connected OH-Group");
             }
         } else if (FunctionalGroupsFinder.isHeteroatom(aFunctionalGroupAtom)) {
             tmpRAtomCount += aFunctionalGroupAtom.getImplicitHydrogenCount();
@@ -1005,13 +1060,13 @@ public class FunctionalGroupsFinder {
             aFunctionalGroupAtom.setImplicitHydrogenCount(0);
         }
         if (FunctionalGroupsFinder.isDbg()) {
-            FunctionalGroupsFinder.LOGGING_TOOL.debug(String.format(
+            FunctionalGroupsFinder.LOGGER.debug(String.format(
                     "\t\texpanded environment: %dx R-atom (incl. %d for H replacement)",
                     tmpRAtomCount,
                     tmpRAtomCount - tmpRAtomsForCCount));
         }
     }
-    //
+
     /**
      * Add explicit hydrogen atoms to an atom in a molecule.
      *
@@ -1028,7 +1083,7 @@ public class FunctionalGroupsFinder {
             aMolecule.addBond(anAtom.getBuilder().newInstance(IBond.class, anAtom, tmpHydrogenAtom, Order.SINGLE));
         }
     }
-    //
+
     /**
      * Add pseudo ("R") atoms to an atom in a molecule.
      *
@@ -1045,15 +1100,22 @@ public class FunctionalGroupsFinder {
             aMolecule.addBond(anAtom.getBuilder().newInstance(IBond.class, anAtom, tmpRAtom, Order.SINGLE));
         }
     }
-    //
+
     /**
-     * Partitions the marked atoms and their processed environments into separate functional groups and builds atom containers
-     * for them as final step before returning them. Transfers the respective atoms, bonds, single electrons, and lone
-     * pairs from the source atom container to the new functional group atom containers.
+     * Partitions the marked atoms and their processed environments into
+     * separate functional groups and builds atom containers for them as final
+     * step before returning them. Transfers the respective atoms, bonds, single
+     * electrons, and lone pairs from the source atom container to the new
+     * functional group atom containers.
      *
-     * @param aSourceContainer molecule atom container to take atoms, bonds, and electron objects from
-     * @param anAtomIdxToFGIdxMap array that maps atom indices (array positions) to functional group indices that the atoms belong to
-     * @param aFunctionalGroupCount maximum functional group index (+1) to know how many functional group atom containers to build
+     * @param aSourceContainer molecule atom container to take atoms, bonds,
+     *                         and electron objects from
+     * @param anAtomIdxToFGIdxMap array that maps atom indices (array positions)
+     *                            to functional group indices that the atoms
+     *                            belong to
+     * @param aFunctionalGroupCount maximum functional group index (+1) to know
+     *                              how many functional group atom containers
+     *                              to build
      * @return list of partitioned functional group atom containers
      */
     private List<IAtomContainer> partitionIntoGroups(IAtomContainer aSourceContainer, int[] anAtomIdxToFGIdxMap, int aFunctionalGroupCount) {
@@ -1099,7 +1161,7 @@ public class FunctionalGroupsFinder {
         }
         return tmpFunctionalGroups;
     }
-    //
+
     /**
      * Clear caches related to the input molecule. Note, these are not proper caches, there are no results cached. Here,
      * only data taken from the input molecule is saved for only one execution of the extractFunctionalGroups() method, to facilitate
@@ -1112,12 +1174,14 @@ public class FunctionalGroupsFinder {
         this.aromaticHeteroAtomIndicesToIsInGroupBoolMapCache = null;
         this.markedAtomToConnectedEnvCMapCache = null;
     }
-    //
+
     /**
-     * Checks input molecule for charged atoms, metal or metalloid atoms, and whether it consists of more than one
-     * unconnected structures. The molecule may be empty but not null.
-     * If one of the cases applies, an IllegalArgumentException is thrown with a specific error message.
-     * Given as static method here because it is used by static public utility methods (developer's note).
+     * Checks input molecule for charged atoms, metal or metalloid atoms, and
+     * whether it consists of more than one unconnected structures. The molecule
+     * may be empty but not null. If one of the cases applies, an
+     * IllegalArgumentException is thrown with a specific error message.
+     * Given as static method here because it is used by static public utility
+     * methods (developer's note).
      *
      * @param aMolecule the molecule to check
      * @throws IllegalArgumentException if one of the constraints is not met
@@ -1139,11 +1203,12 @@ public class FunctionalGroupsFinder {
             throw new IllegalArgumentException("Input molecule must consist of only a single connected structure.");
         }
     }
-    //
+
     /**
-     * Checks whether the given atom is a pseudo atom. Very strict, any atom whose atomic number is
-     * null or 0, whose symbol equals "R" or "*", or that is an instance of an IPseudoAtom implementing
-     * class will be classified as a pseudo atom.
+     * Checks whether the given atom is a pseudo atom. Very strict, any atom
+     * whose atomic number is null or 0, whose symbol equals "R" or "*", or that
+     * is an instance of an IPseudoAtom implementing class will be classified as
+     * a pseudo atom.
      *
      * @param anAtom the atom to test
      * @return true if the given atom is identified as a pseudo (R) atom
@@ -1159,13 +1224,14 @@ public class FunctionalGroupsFinder {
                 tmpSymbol.equals("*") ||
                 anAtom instanceof IPseudoAtom;
     }
-    //
+
     /**
-     * Checks whether the given atom is a hetero-atom (i.e. non-carbon and non-hydrogen).
-     * Pseudo (R) atoms will also return false.
+     * Checks whether the given atom is a hetero-atom (i.e. non-carbon and
+     * non-hydrogen). Pseudo (R) atoms will also return false.
      *
      * @param anAtom the atom to test
-     * @return true if the given atom is neither a carbon nor a hydrogen or pseudo atom
+     * @return true if the given atom is neither a carbon nor a hydrogen or
+     *         pseudo atom
      */
     private static boolean isHeteroatom(IAtom anAtom) {
         Integer tmpAtomicNr = anAtom.getAtomicNumber();
@@ -1176,13 +1242,15 @@ public class FunctionalGroupsFinder {
         return tmpAtomicNumberInt != IAtom.H && tmpAtomicNumberInt != IAtom.C
                 && !FunctionalGroupsFinder.isPseudoAtom(anAtom);
     }
-    //
+
     /**
-     * Checks whether the given atom is from an element in the organic subset, i.e. not a metal or metalloid atom.
+     * Checks whether the given atom is from an element in the organic subset,
+     * i.e. not a metal or metalloid atom.
      * Pseudo (R) atoms will also return false.
      *
      * @param anAtom atom to check
-     * @return true if the given atom is organic and not a metal or metalloid atom
+     * @return true if the given atom is organic and not a metal or metalloid
+     *         atom
      */
     private static boolean isNonmetal(IAtom anAtom) {
         Integer tmpAtomicNumber = anAtom.getAtomicNumber();
@@ -1192,9 +1260,10 @@ public class FunctionalGroupsFinder {
         int tmpAtomicNumberInt = tmpAtomicNumber;
         return !Elements.isMetal(tmpAtomicNumberInt) && !Elements.isMetalloid(tmpAtomicNumberInt) && !FunctionalGroupsFinder.isPseudoAtom(anAtom);
     }
-    //
+
     /**
-     * Returns whether the CDK logging tool of this class (logger) is currently configured to log debug messages.
+     * Returns whether the CDK logging tool of this class (logger) is currently
+     * configured to log debug messages.
      * <p>
      *     Use <code>FunctionalGroupsFinder.LOGGING_TOOL.setLevel(ILoggingTool.DEBUG);</code>  to activate debug messages.
      * </p>
@@ -1202,6 +1271,6 @@ public class FunctionalGroupsFinder {
      * @return true if debug messages are enabled
      */
     private static boolean isDbg() {
-        return FunctionalGroupsFinder.LOGGING_TOOL.isDebugEnabled();
+        return FunctionalGroupsFinder.LOGGER.isDebugEnabled();
     }
 }

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -37,6 +37,8 @@ import org.openscience.cdk.interfaces.ISingleElectron;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -906,8 +908,8 @@ public class FunctionalGroupsFinder {
 
         if (mol == null)
             throw new NullPointerException("No molecule provided");
-        if (strict)
-            FunctionalGroupsFinder.checkConstraints(mol);
+        if (strict && !FunctionalGroupsFinder.checkConstraints(mol))
+            return Collections.emptyList();
 
         State state = new State();
         state.markAtoms(mol);

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -242,8 +242,6 @@ public class FunctionalGroupsFinder {
         }
     }
 
-    private static final ILoggingTool LOGGER = LoggingToolFactory.createLoggingTool(FunctionalGroupsFinder.class);
-
     /**
      * Property name for marking carbonyl carbon atoms via IAtom properties.
      */
@@ -404,9 +402,6 @@ public class FunctionalGroupsFinder {
                     hCounts[atom.getIndex()] = atom.getImplicitHydrogenCount();
             }
 
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug("########## Starting search for atoms to mark ... ##########");
-            }
             // store marked atoms
             markedAtomsCache = new HashSet<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
             // store aromatic heteroatoms
@@ -440,31 +435,15 @@ public class FunctionalGroupsFinder {
                                 && !bond.isAromatic())) {
 
                             // set the *connected* atom as marked (add() true if this set did not already contain the specified element)
-                            if (markedAtomsCache.add(nbor.getIndex())) {
-                                if (FunctionalGroupsFinder.isDbg()) {
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                            "Marking Atom #%d (%s) - Met condition %s",
-                                            nbor.getIndex(),
-                                            nbor.getSymbol(),
-                                            nbor.getAtomicNumber() == IAtom.C ? "2.1/2.2" : "1"));
-                                }
-                            }
+                            markedAtomsCache.add(nbor.getIndex());
                             // set the *current* atom as marked and break out of connected atoms
                             tmpIsMarked = true;
-                            if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                        "Marking Atom #%d (%s) - Met condition 2.1/2.2",
-                                        idx,
-                                        atom.getSymbol()));
-                            }
+
                             // but check for carbonyl-C before break
                             if (nbor.getAtomicNumber() == IAtom.O
                                     && bond.getOrder() == Order.DOUBLE
                                     && atom.getBondCount() == 3) {
                                 atom.setProperty(CARBONYL_C_MARKER, true);
-                                if (FunctionalGroupsFinder.isDbg())  {
-                                    FunctionalGroupsFinder.LOGGER.debug("- was flagged as Carbonly-C");
-                                }
                             }
                             // break out of connected atoms
                             break;
@@ -477,24 +456,13 @@ public class FunctionalGroupsFinder {
                             if (!nbor.isAromatic()) {
                                 // set the connected O/N/S atom as marked
                                 markedAtomsCache.add(nbor.getIndex());
-                                if (FunctionalGroupsFinder.isDbg()) {
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                            "Marking Atom #%d (%s) - Met condition 1",
-                                            nbor.getIndex(),
-                                            nbor.getSymbol()));
-                                }
+
                                 // if "acetal C" (2+ O/N/S in single bonds connected to sp3-C)... [CONDITION 2.3]
                                 if (isSaturated(nbor)) {
                                     tmpConnectedONSatomsCounter++;
                                     if (tmpConnectedONSatomsCounter > 1 && atom.getBondCount() + hCounts[atom.getIndex()] == 4) {
                                         // set as marked and break out of connected atoms
                                         tmpIsMarked = true;
-                                        if (FunctionalGroupsFinder.isDbg()) {
-                                            FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                                    "Marking Atom #%d (%s) - Met condition 2.3",
-                                                    idx,
-                                                    atom.getSymbol()));
-                                        }
                                         break;
                                     }
                                 }
@@ -509,24 +477,8 @@ public class FunctionalGroupsFinder {
                                 // set connected atoms as marked
                                 markedAtomsCache.add(nbor.getIndex());
                                 markedAtomsCache.add(nbor2.getIndex());
-                                if (FunctionalGroupsFinder.isDbg()) {
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                            "Marking Atom #%d (%s) - Met condition 2.4",
-                                            nbor.getIndex(),
-                                            nbor.getSymbol()));
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                            "Marking Atom #%d (%s) - Met condition 2.4",
-                                            nbor2.getIndex(),
-                                            nbor2.getSymbol()));
-                                }
                                 // set current atom as marked and break out of connected atoms
                                 tmpIsMarked = true;
-                                if (FunctionalGroupsFinder.isDbg()) {
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                            "Marking Atom #%d (%s) - Met condition 2.4",
-                                            idx,
-                                            atom.getSymbol()));
-                                }
                                 break;
                             }
                         } // end of else if connected to O/N/S in single bond
@@ -544,22 +496,10 @@ public class FunctionalGroupsFinder {
                 } else if (isHeteroatom(atom)) {
                     // if heteroatom... (CONDITION 1)
                     markedAtomsCache.add(idx);
-                    if (FunctionalGroupsFinder.isDbg()) {
-                        FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                "Marking Atom #%d (%s) - Met condition 1",
-                                idx,
-                                atom.getSymbol()));
-                    }
                 } else {
                     //pseudo (R) atom, ignored
                 }
             } //end of for loop that iterates over all atoms in the mol
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug(String.format(
-                        "########## End of search. Marked %d/%d atoms. ##########",
-                        markedAtomsCache.size(),
-                        mol.getAtomCount()));
-            }
         }
 
         /**
@@ -705,18 +645,12 @@ public class FunctionalGroupsFinder {
          * @param parts  the list of functional groups including "environments"
          */
         private void expandGeneralizedEnvironments(List<IAtomContainer> parts) {
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug("########## Starting generalization of functional groups... ##########");
-            }
             Map<IAtom,IAtom> invMap = new HashMap<>();
             for (Map.Entry<IAtom,IAtom> e : amap.entrySet())
                 invMap.put(e.getValue(), e.getKey());
 
             for (IAtomContainer part : parts) {
                 int acount = part.getAtomCount();
-                if(FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGER.debug(String.format("Generalizing functional group (%d atoms)...", acount));
-                }
                 // pre-checking for special cases...
                 if (part.getAtomCount() == 1) {
                     IAtom cpyAtom = part.getAtom(0);
@@ -728,18 +662,9 @@ public class FunctionalGroupsFinder {
                         // for H2N-C_env & HO-C_env -> do not replace H & C_env by R to differentiate primary/secondary/tertiary amine and alcohol vs. phenol
                         if ((cpyAtom.getAtomicNumber() == IAtom.O && tmpEnvCCount == 1)
                                 || (cpyAtom.getAtomicNumber() == IAtom.N && tmpEnvCCount == 1)) {
-                            if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                        "\t- found single atomic %s FG with one env. C. Expanding environment...",
-                                        cpyAtom.getSymbol()));
-                            }
                             expandEnvironment(orgAtom, part);
                             int hcount = cpyAtom.getImplicitHydrogenCount();
                             if (hcount != 0) {
-                                if (FunctionalGroupsFinder.isDbg()) {
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                            "\t- adding %d hydrogens...", hcount));
-                                }
                                 addHydrogens(cpyAtom, hcount, part);
                                 cpyAtom.setImplicitHydrogenCount(0);
                             }
@@ -748,20 +673,10 @@ public class FunctionalGroupsFinder {
                         // for HN-(C_env)-C_env & HS-C_env -> do not replace H by R! (only C_env!)
                         if ((cpyAtom.getAtomicNumber() == IAtom.N && tmpEnvCCount == 2)
                                 || (cpyAtom.getAtomicNumber() == IAtom.S && tmpEnvCCount == 1)) {
-                            if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGER.debug("\t- found sec. amine or simple thiol");
-                            }
                             int hcount = cpyAtom.getImplicitHydrogenCount();
                             if (hcount != 0) {
-                                if (FunctionalGroupsFinder.isDbg()) {
-                                    FunctionalGroupsFinder.LOGGER.debug(String.format("\t- adding %d hydrogens...",
-                                                                                      hcount));
-                                }
                                 addHydrogens(cpyAtom, hcount, part);
                                 cpyAtom.setImplicitHydrogenCount(0);
-                            }
-                            if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGER.debug("\t- expanding environment...");
                             }
                             expandEnvironmentGeneralized(orgAtom, part);
                             continue;
@@ -774,13 +689,6 @@ public class FunctionalGroupsFinder {
                             cpyAtom.setImplicitHydrogenCount(0);
                         }
                         String tmpAtomTypeName = cpyAtom.getAtomTypeName();
-                        if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                    "\t- found single aromatic heteroatom (%s, Atomtype %s). Adding %d R-Atoms...",
-                                    cpyAtom.getSymbol(),
-                                    tmpAtomTypeName,
-                                    rcount));
-                        }
                         addRAtoms(cpyAtom, rcount, part);
                         continue;
                     }
@@ -797,12 +705,6 @@ public class FunctionalGroupsFinder {
                             cpyAtom.setImplicitHydrogenCount(0);
                         }
                         int tmpRAtomCount = orgAtom.getValency() - 1;
-                        if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                    "\t- found connected aromatic heteroatom (%s). Adding %d R-Atoms...",
-                                    orgAtom.getSymbol(),
-                                    tmpRAtomCount));
-                        }
                         addRAtoms(cpyAtom, tmpRAtomCount, part);
                     }
                     // processing carbons...
@@ -811,30 +713,17 @@ public class FunctionalGroupsFinder {
                             if (hCounts[orgAtom.getIndex()] != 0) {
                                 cpyAtom.setImplicitHydrogenCount(0);
                             }
-                            if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGER.debug("\t- ignoring environment for marked carbon atom");
-                            }
                             continue;
                         } else {
-                            if (FunctionalGroupsFinder.isDbg()) {
-                                FunctionalGroupsFinder.LOGGER.debug("\t- found carbonyl-carbon. Expanding environment...");
-                            }
                             expandEnvironmentGeneralized(orgAtom, part);
                             continue;
                         }
                     } else { // processing heteroatoms...
-                        if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGER.debug(String.format("\t- found heteroatom (%s). Expanding environment...",
-                                                                              orgAtom.getSymbol()));
-                        }
                         expandEnvironmentGeneralized(orgAtom, part);
                         continue;
                     }
                 }
             } //end of loop over given functional groups list
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug("########## Generalization of functional groups completed. ##########");
-            }
         }
 
         /**
@@ -845,41 +734,23 @@ public class FunctionalGroupsFinder {
          *                               their "environments"
          */
         private void expandFullEnvironments(List<IAtomContainer> parts) {
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug("########## Starting expansion of full environments for functional groups... ##########");
-            }
             Map<IAtom,IAtom> invMap = new HashMap<>();
             for (Map.Entry<IAtom,IAtom> e : amap.entrySet())
                 invMap.put(e.getValue(), e.getKey());
 
             for (IAtomContainer part : parts) {
                 int acount = part.getAtomCount();
-                if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGER.debug(String.format(
-                            "Expanding environment on functional group (%d atoms)...", acount));
-                }
                 for (int i = 0; i < acount; i++) {
                     IAtom cpyAtom = part.getAtom(i);
                     IAtom orgAtom = (IAtom)invMap.get(cpyAtom);
 
-                    if (FunctionalGroupsFinder.isDbg()) {
-                        FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                " - Atom #%d   - Expanding environment...", i));
-                    }
                     expandEnvironment(orgAtom, part);
                     int tmpImplicitHydrogenCount = cpyAtom.getImplicitHydrogenCount();
                     if (tmpImplicitHydrogenCount != 0) {
-                        if (FunctionalGroupsFinder.isDbg()) {
-                            FunctionalGroupsFinder.LOGGER.debug(String.format(
-                                    "\t- adding %d hydrogens...", tmpImplicitHydrogenCount));
-                        }
                         addHydrogens(cpyAtom, tmpImplicitHydrogenCount, part);
                         cpyAtom.setImplicitHydrogenCount(0);
                     }
                 }
-            }
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug("########## Expansion of full environments for functional groups completed. ##########");
             }
         }
 
@@ -896,9 +767,6 @@ public class FunctionalGroupsFinder {
             IAtom cpyAtom = (IAtom) amap.get(orgAtom);
 
             if (Objects.isNull(tmpEnvCAtomsList) || tmpEnvCAtomsList.isEmpty()) {
-                if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGER.debug("\t\tfound no environment to expand.");
-                }
                 return;
             }
             int tmpAromaticCAtomCount = 0;
@@ -917,12 +785,6 @@ public class FunctionalGroupsFinder {
                 part.addAtom(tmpCAtom);
                 part.addBond(tmpBond);
             }
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug(String.format(
-                        "\t\texpanded environment: %dx C_ar and %dx C_al",
-                        tmpAromaticCAtomCount,
-                        tmpAliphaticCAtomCount));
-            }
         }
 
         /**
@@ -938,9 +800,6 @@ public class FunctionalGroupsFinder {
             List<EnvironmentalC> tmpEnvironment = markedAtomToConnectedEnvCMapCache.get(orgAtom);
             IAtom cpyAtom = (IAtom) amap.get(orgAtom);
             if (Objects.isNull(tmpEnvironment)) {
-                if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGER.debug("\t\tfound no environment to expand.");
-                }
                 return;
             }
             int tmpRAtomCount = tmpEnvironment.size();
@@ -948,21 +807,12 @@ public class FunctionalGroupsFinder {
             if (cpyAtom.getAtomicNumber() == IAtom.O && cpyAtom.getImplicitHydrogenCount() == 1) {
                 addHydrogens(cpyAtom, 1, cpyPart);
                 cpyAtom.setImplicitHydrogenCount(0);
-                if (FunctionalGroupsFinder.isDbg()) {
-                    FunctionalGroupsFinder.LOGGER.debug("\t\texpanded hydrogen on connected OH-Group");
-                }
             } else if (isHeteroatom(cpyAtom)) {
                 tmpRAtomCount += cpyAtom.getImplicitHydrogenCount();
             }
             addRAtoms(cpyAtom, tmpRAtomCount, cpyPart);
             if (cpyAtom.getImplicitHydrogenCount() != 0) {
                 cpyAtom.setImplicitHydrogenCount(0);
-            }
-            if (FunctionalGroupsFinder.isDbg()) {
-                FunctionalGroupsFinder.LOGGER.debug(String.format(
-                        "\t\texpanded environment: %dx R-atom (incl. %d for H replacement)",
-                        tmpRAtomCount,
-                        tmpRAtomCount - tmpRAtomsForCCount));
             }
         }
     }
@@ -1137,18 +987,5 @@ public class FunctionalGroupsFinder {
         if (!ConnectivityChecker.isConnected(aMolecule)) {
             throw new IllegalArgumentException("Input molecule must consist of only a single connected structure.");
         }
-    }
-
-    /**
-     * Returns whether the CDK logging tool of this class (logger) is currently
-     * configured to log debug messages.
-     * <p>
-     *     Use <code>FunctionalGroupsFinder.LOGGING_TOOL.setLevel(ILoggingTool.DEBUG);</code>  to activate debug messages.
-     * </p>
-     *
-     * @return true if debug messages are enabled
-     */
-    private static boolean isDbg() {
-        return FunctionalGroupsFinder.LOGGER.isDebugEnabled();
     }
 }

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -936,7 +936,7 @@ public class FunctionalGroupsFinder {
      *
      * @param mol the molecule to check
      */
-    private static boolean checkConstraints(IAtomContainer mol) {
+    public static boolean checkConstraints(IAtomContainer mol) {
         for (IAtom atom : mol.atoms()) {
             if (atom.getFormalCharge() != null && atom.getFormalCharge() != 0)
                 return false;

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -25,6 +25,7 @@
 package org.openscience.cdk.fragment;
 
 import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.graph.ConnectivityChecker;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.graph.GraphUtil.EdgeToBondMap;
@@ -253,7 +254,7 @@ public class FunctionalGroupsFinder {
      * Environment mode setting, defining whether environments should be
      * generalized (default) or kept as whole.
      */
-    private Environment envEnvironment;
+    private final Environment envEnvironment;
 
     /**
      * Set for atoms marked as being part of a functional group, represented

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -35,8 +35,6 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.ILonePair;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.ISingleElectron;
-import org.openscience.cdk.tools.ILoggingTool;
-import org.openscience.cdk.tools.LoggingToolFactory;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -742,7 +740,7 @@ public class FunctionalGroupsFinder {
                 int acount = part.getAtomCount();
                 for (int i = 0; i < acount; i++) {
                     IAtom cpyAtom = part.getAtom(i);
-                    IAtom orgAtom = (IAtom)invMap.get(cpyAtom);
+                    IAtom orgAtom = invMap.get(cpyAtom);
 
                     expandEnvironment(orgAtom, part);
                     int tmpImplicitHydrogenCount = cpyAtom.getImplicitHydrogenCount();

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -1025,7 +1025,7 @@ public class FunctionalGroupsFinder {
      *                                  hydrogen counts are unset
      * @return a list with all functional groups found in the molecule
      */
-    public List<IAtomContainer> extract(IAtomContainer aMolecule) throws IllegalArgumentException {
+    public List<IAtomContainer> extract(IAtomContainer aMolecule) {
         return this.extract(aMolecule, false);
     }
 
@@ -1059,7 +1059,7 @@ public class FunctionalGroupsFinder {
      *                                  the given molecule does not fulfill them
      * @return a list with all functional groups found in the molecule
      */
-    public List<IAtomContainer> extract(IAtomContainer mol, boolean anAreInputRestrictionsApplied) throws IllegalArgumentException {
+    public List<IAtomContainer> extract(IAtomContainer mol, boolean anAreInputRestrictionsApplied) {
         if (anAreInputRestrictionsApplied) {
             // throws IllegalArgumentException if constraints are not met
             // only done now because adjacency list cache is needed in the method

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.aromaticity.ElectronDonation;
+import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
@@ -57,11 +58,11 @@ import java.util.Map;
  * @author Sebastian Fritsch, Jonas Schaub
  * @version 1.3
  */
-public class FunctionalGroupsFinderTest {
+class FunctionalGroupsFinderTest {
     /**
      * Constructor.
      */
-    public FunctionalGroupsFinderTest() {
+    FunctionalGroupsFinderTest() {
         super();
     }
     //
@@ -72,7 +73,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void gitHubWikiTest() throws Exception {
+    void gitHubWikiTest() throws Exception {
         //Prepare input
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer tmpInputMol = tmpSmiPar.parseSmiles("C[C@@H]1CN(C[C@H](C)N1)C2=C(C(=C3C(=C2F)N(C=C(C3=O)C(=O)O)C4CC4)N)F"); //PubChem CID 5257
@@ -102,19 +103,19 @@ public class FunctionalGroupsFinderTest {
      * @throws Exception
      */
     @Test
-    public void testInputRestrictions() throws Exception {
+    void testInputRestrictions() throws Exception {
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         String tmpMoleculeSmiles = "CC(=O)OC1=CC=CC=C1C(=O)[O+]"; //charged ASA
         IAtomContainer tmpChargedASA = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
         Assertions.assertFalse(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpChargedASA));
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpChargedASA, true, true);
+            FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpChargedASA, true);
         });
         tmpMoleculeSmiles = "CC(=O)OC1=CC=CC=C1C(=O)O"; //neutral ASA
         IAtomContainer tmpASA = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
         Assertions.assertTrue(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpASA));
         Assertions.assertDoesNotThrow(() -> {
-            FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpASA, true, true);
+            FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpASA, true);
         });
         tmpMoleculeSmiles = "C1=CC(=CC=C1[N+](=O)[O-])O"; //Nitrophenol
         IAtomContainer tmpNitrophenol = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
@@ -137,7 +138,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind1() throws Exception {
+    void testFind1() throws Exception {
         String tmpMoleculeSmiles = "Cc1cc(C)nc(NS(=O)(=O)c2ccc(N)cc2)n1";
         String[] tmpExpectedFGs = new String[] {"[R]N([R])S(=O)(=O)[R]", "[c]N(H)H", "NarR3", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -150,7 +151,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind2() throws Exception {
+    void testFind2() throws Exception {
         String tmpMoleculeSmiles = "NC(=N)c1ccc(\\\\C=C\\\\c2ccc(cc2O)C(=N)N)cc1";
         String[] tmpExpectedFGs = new String[] {"[R]N=C-N([R])[R]", "[C]=[C]", "[c]OH", "[R]N=C-N([R])[R]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -163,7 +164,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind3() throws Exception {
+    void testFind3() throws Exception {
         String tmpMoleculeSmiles = "CC(=O)Nc1nnc(s1)S(=O)(=O)N";
         String[] tmpExpectedFGs = new String[] {"[R]N([R])C(=O)[R]", "[R]S(=O)(=O)N([R])[R]", "NarR3", "NarR3", "SarR2"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -176,7 +177,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind4() throws Exception {
+    void testFind4() throws Exception {
         String tmpMoleculeSmiles = "NS(=O)(=O)c1cc2c(NCNS2(=O)=O)cc1Cl";
         String[] tmpExpectedFGs = new String[] {"[R]S(=O)(=O)N([R])[R]", "[R]S(=O)(=O)N([R])[C]N([R])[R]", "[R]Cl"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -189,7 +190,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind5() throws Exception {
+    void testFind5() throws Exception {
         String tmpMoleculeSmiles = "CNC1=Nc2ccc(Cl)cc2C(=N(=O)C1)c3ccccc3";
         String[] tmpExpectedFGs = new String[] {"[R]N([R])[C]=N[R]", "[R]Cl", "[R]N(=O)=[C]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -202,7 +203,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind6() throws Exception {
+    void testFind6() throws Exception {
         String tmpMoleculeSmiles = "Cc1onc(c2ccccc2)c1C(=O)N[C@H]3[C@H]4SC(C)(C)[C@@H](N4C3=O)C(=O)O";
         String[] tmpExpectedFGs = new String[] {"O=C([R])N([R])[R]",  "O=C([R])N([R])[C]S[R]", "O=C([R])OH", "OarR2", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -215,7 +216,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind7() throws Exception {
+    void testFind7() throws Exception {
         String tmpMoleculeSmiles = "Clc1ccccc1C2=NCC(=O)Nc3ccc(cc23)N(=O)=O";
         String[] tmpExpectedFGs = new String[] {"[R]Cl", "[R]N=[C]", "[R]C(=O)N([R])[R]", "O=N([R])=O"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -228,7 +229,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind8() throws Exception {
+    void testFind8() throws Exception {
         String tmpMoleculeSmiles = "COc1cc(cc(C(=O)NCC2CCCN2CC=C)c1OC)S(=O)(=O)N";
         String[] tmpExpectedFGs = new String[] {"[R]O[R]", "[R]N([R])C(=O)[R]", "N([R])([R])[R]", "[C]=[C]", "[R]O[R]", "[R]S(=O)(=O)N([R])[R]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -241,7 +242,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind9() throws Exception {
+    void testFind9() throws Exception {
         String tmpMoleculeSmiles = "Cc1ccc(Cl)c(Nc2ccccc2C(=O)O)c1Cl";
         String[] tmpExpectedFGs = new String[] {"[R]Cl", "[R]N(H)[R]", "O=C(OH)[R]", "[R]Cl"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -254,7 +255,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind10() throws Exception {
+    void testFind10() throws Exception {
         String tmpMoleculeSmiles = "Clc1ccc2Oc3ccccc3N=C(N4CCNCC4)c2c1";
         String[] tmpExpectedFGs = new String[] {"[R]Cl", "[R]O[R]", "[R]N([R])[C]=N[R]", "[R]N([H])[R]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -267,7 +268,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind11() throws Exception {
+    void testFind11() throws Exception {
         String tmpMoleculeSmiles = "FC(F)(F)CN1C(=O)CN=C(c2ccccc2)c3cc(Cl)ccc13";
         String[] tmpExpectedFGs = new String[] {"[R]F", "[R]F", "[R]F", "O=C([R])N([R])[R]", "[R]N=[C]", "[R]Cl"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -280,7 +281,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind12() throws Exception {
+    void testFind12() throws Exception {
         String tmpMoleculeSmiles = "OC[C@H]1O[C@H](C[C@@H]1O)n2cnc3[C@H](O)CNC=Nc23";
         String[] tmpExpectedFGs = new String[] {"[C]O[H]", "[R]O[R]", "[C]OH", "[C]OH", "[R]N=CN([R])[R]", "NarR3", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -293,7 +294,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind13() throws Exception {
+    void testFind13() throws Exception {
         String tmpMoleculeSmiles = "CCN[C@H]1C[C@H](C)S(=O)(=O)c2sc(cc12)S(=O)(=O)N";
         String[] tmpExpectedFGs = new String[] {"[R]N([R])H", "O=S(=O)([R])[R]", "[R]S(=O)(=O)N([R])[R]", "SarR2"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -306,7 +307,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind14() throws Exception {
+    void testFind14() throws Exception {
         String tmpMoleculeSmiles = "C[C@@H](O)[C@@H]1[C@H]2[C@@H](C)C(=C(N2C1=O)C(=O)O)S[C@@H]3CN[C@@H](C3)C(=O)N(C)C";
         String[] tmpExpectedFGs = new String[] {"[C]O[H]", "O=C([R])N([R])C(C(=O)(OH))=[C]S[R]", "[R]N(H)[R]", "[R]N([R])C([R])=O"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -319,7 +320,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind15() throws Exception {
+    void testFind15() throws Exception {
         String tmpMoleculeSmiles = "C[C@@H]1CN(C[C@H](C)N1)c2c(F)c(N)c3C(=O)C(=CN(C4CC4)c3c2F)C(=O)O";
         String[] tmpExpectedFGs = new String[] {"[R]N([R])[R]", "[R]N([H])[R]", "[R]F", "[c]N(H)H", "[c]=O", "[R]F", "[R]C(=O)OH", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -332,7 +333,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind16() throws Exception {
+    void testFind16() throws Exception {
         String tmpMoleculeSmiles = "CC(=CCC1C(=O)N(N(C1=O)c2ccccc2)c3ccccc3)C";
         String[] tmpExpectedFGs = new String[] {"[C]=[C]", "[R]C(=O)N([R])N([R])C(=O)[R]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -345,7 +346,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind17() throws Exception {
+    void testFind17() throws Exception {
         String tmpMoleculeSmiles = "Clc1ccc2N=C3NC(=O)CN3Cc2c1Cl";
         String[] tmpExpectedFGs = new String[] {"Cl[R]", "[R]N=C(N([R])[R])N([R])C(=O)[R]", "Cl[R]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -358,7 +359,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind18() throws Exception {
+    void testFind18() throws Exception {
         String tmpMoleculeSmiles = "CC(=O)N[C@@H]1[C@@H](NC(=N)N)C=C(O[C@H]1[C@H](O)[C@H](O)CO)C(=O)O";
         String[] tmpExpectedFGs = new String[] {"[R]N([R])C(=O)[R]", "[R]N([R])C(=N[R])N([R])[R]", "O=C(OH)C(=[C])O[R]" , "[C]OH", "[C]OH", "[C]OH"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -371,7 +372,7 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind19() throws Exception {
+    void testFind19() throws Exception {
         String tmpMoleculeSmiles = "C[C@H](O)[C@H](O)[C@H]1CNc2nc(N)nc(O)c2N1";
         String[] tmpExpectedFGs = new String[] {"[C]OH", "[C]OH", "[R]N(H)[R]" , "[c]N(H)H",  "[c]OH", "[R]N(H)[R]", "NarR3", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -384,14 +385,14 @@ public class FunctionalGroupsFinderTest {
      * @author Sebastian Fritsch
      */
     @Test
-    public void testFind20() throws Exception {
+    void testFind20() throws Exception {
         String tmpMoleculeSmiles = "N[C@@H]1CCCCN(C1)c2c(Cl)cc3C(=O)C(=CN(C4CC4)c3c2Cl)C(=O)O";
         String[] tmpExpectedFGs = new String[] {"[C]N([H])[H]", "[R]N([R])[R]", "[R]Cl" , "[c]=O", "[R]Cl", "[R]C(=O)OH", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
     }
 
     @Test
-    public void testOxirane() throws Exception {
+    void testOxirane() throws Exception {
         String tmpMoleculeSmiles = "CCCCCC1OC1";
         String[] tmpExpectedFGs = new String[] {"C1OC1"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -405,7 +406,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testOnlyMarkedAtoms1() throws Exception {
+    void testOnlyMarkedAtoms1() throws Exception {
         String tmpMoleculeSmiles = "CCO[Si](OCC)(OCC)OCC"; //Tetraethyl Orthosilicate
         String[] tmpExpectedFGs = new String[]{"[O][Si]([O])([O])[O]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs, new Aromaticity(ElectronDonation.daylight(), Cycles.all()), FunctionalGroupsFinder.Environment.NONE);
@@ -419,7 +420,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testOnlyMarkedAtoms2() throws Exception {
+    void testOnlyMarkedAtoms2() throws Exception {
         String tmpMoleculeSmiles = "Cc1cc(C)nc(NS(=O)(=O)c2ccc(N)cc2)n1"; //same mol as testFind1() from the Ertl figure
         String[] tmpExpectedFGs = new String[] {"O=[S](=O)[NH]", "[NH2]", "Nar" , "Nar"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs, new Aromaticity(ElectronDonation.daylight(), Cycles.all()), FunctionalGroupsFinder.Environment.NONE);
@@ -433,7 +434,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testOnlyMarkedAtoms3() throws Exception {
+    void testOnlyMarkedAtoms3() throws Exception {
         String tmpMoleculeSmiles = "CO/N=C(\\C(=O)N[C@@H]1C(=O)N2C(C(=O)[O-])=C(C[N+]3(C)CCCC3)CS[C@H]12)c1csc(N)n1.Cl"; //CHEMBL1201736
         String[] tmpExpectedFGs = new String[] {"[O]N=[C]C(=O)[NH]", "[C]=C(C(=O)[O-])N([C]=O)[CH][S]", "[N+]", "[NH2]", "Cl", "Sar", "Nar"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs, new Aromaticity(ElectronDonation.daylight(), Cycles.all()), FunctionalGroupsFinder.Environment.NONE);
@@ -447,7 +448,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testChargedMolecules1() throws Exception {
+    void testChargedMolecules1() throws Exception {
         String tmpMoleculeSmiles = "CC(=O)OC1=CC=CC=C1C(=O)[O+]"; //charged ASA
         String[] tmpExpectedFGs = new String[] {"*OC(*)=O", "*C(=O)[O+]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -461,7 +462,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testChargedMolecules2() throws Exception {
+    void testChargedMolecules2() throws Exception {
         String tmpMoleculeSmiles = "C1=CC(=CC=C1[N+](=O)[O-])O"; //Nitrophenol
         String[] tmpExpectedFGs = new String[] {"*[N+](=O)[O-]", "[H]O[c]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -475,7 +476,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testChargedMolecules3() throws Exception {
+    void testChargedMolecules3() throws Exception {
         String tmpMoleculeSmiles = "C[N+](C)(C)C"; //Tetramethylammonium
         String[] tmpExpectedFGs = new String[] {"*[N+](*)(*)*"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -489,7 +490,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testChargedMolecules4() throws Exception {
+    void testChargedMolecules4() throws Exception {
         String tmpMoleculeSmiles = "c1ccccc1[CH+]C(Br)C"; //Carbenium ion in beta position to Br
         // carbenium ion is ignored since a charge is not a reason to mark carbon atom
         String[] tmpExpectedFGs = new String[] {"[C]Br"};
@@ -514,7 +515,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testDisconnectedMolecules1() throws Exception {
+    void testDisconnectedMolecules1() throws Exception {
         String tmpMoleculeSmiles = "CC(=O)O.CC(=O)O.C1=CC(=CC=C1NC(=NC(=NCCCCCCN=C(N)N=C(N)NC2=CC=C(C=C2)Cl)N)N)Cl"; //Chlorhexidine Diacetate
         String[] tmpExpectedFGs = new String[] {"*C(=O)O[H]", "*C(=O)O[H]", "*N=C(N=C(N(*)*)N(*)*)N(*)*", "*N=C(N=C(N(*)*)N(*)*)N(*)*", "*Cl", "*Cl"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -528,7 +529,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testDisconnectedMolecules2() throws Exception {
+    void testDisconnectedMolecules2() throws Exception {
         String tmpMoleculeSmiles = "C(CN(CC(=O)[O-])CC(=O)[O-])N(CC(=O)[O-])CC(=O)[O-].[Na+].[Na+].[Na+].[Na+]"; //Sodium edetate
         String[] tmpExpectedFGs = new String[] {"*N(*)*", "*C(=O)[O-]", "*C(=O)[O-]", "*N(*)*", "*C(=O)[O-]", "*C(=O)[O-]", "[Na+]", "[Na+]", "[Na+]", "[Na+]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -544,7 +545,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testMetalsMetalloids1() throws Exception {
+    void testMetalsMetalloids1() throws Exception {
         String tmpMoleculeSmiles = "CCO[Si](OCC)(OCC)OCC"; //Tetraethyl Orthosilicate
         String[] tmpExpectedFGs = new String[]{"*O[Si](O*)(O*)O*"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -560,7 +561,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testMetalsMetalloids2() throws Exception {
+    void testMetalsMetalloids2() throws Exception {
         String tmpMoleculeSmiles = "O.O.O=[Al]O[Si](=O)O[Si](=O)O[Al]=O"; //Kaolin
         String[] tmpExpectedFGs = new String[]{"*O*", "*O*", "O=[Al]O[Si](=O)O[Si](=O)O[Al]=O"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -575,7 +576,7 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testRAtoms1() throws Exception {
+    void testRAtoms1() throws Exception {
         String tmpMoleculeSmiles = "OCC(CO[*])OC([*])=O"; //CHEBI:598
         String[] tmpExpectedFGs = new String[]{"[H]O[C]", "[C][O]", "*O[C]=O"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
@@ -588,13 +589,20 @@ public class FunctionalGroupsFinderTest {
      * @author Jonas Schaub
      */
     @Test
-    public void testHydrogenBug() throws Exception {
+    void testHydrogenBug() throws Exception {
         String tmpMoleculeSmiles = "[H+].[H+].[O-]C(=O)\\C=C/C([O-])=O.[H][C@@]12Cc3c[nH]c4cccc(C1=C[C@@H](COC(=O)C1CCCCC1)CN2C)c34"; //CHEBI:365445
         String[] tmpExpectedFGs = new String[]{"O=C([O-])[C]=[C]C(=O)[O-]", "[C]=[C]", "*OC(*)=O", "[R]N([R])[R]", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
 
         tmpMoleculeSmiles = "[HH].O=C1N([C@H](C)C(C1=C(O)[C@]2([C@]3([C@H](C=C([C@H]2[C@@H](C(=O)O)CC)C)C[C@H](C)CC3)C)C)=O)C"; //CHEBI:223373
         tmpExpectedFGs = new String[]{"*C(=O)C(=[C]O[H])C(=O)N(*)*", "[C]=[C]", "*C(=O)O[H]"};
+        this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
+    }
+
+    @Test
+    void testB2H6() throws Exception {
+        String tmpMoleculeSmiles = "[H]B1([H])[H]B([H])([H])[H]1";
+        String[] tmpExpectedFGs = new String[]{"[R]B([R])([R])[R]", "[R]B([R])([R])[R]"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
     }
     //

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.aromaticity.ElectronDonation;
-import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
@@ -107,28 +106,26 @@ class FunctionalGroupsFinderTest {
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         String tmpMoleculeSmiles = "CC(=O)OC1=CC=CC=C1C(=O)[O+]"; //charged ASA
         IAtomContainer tmpChargedASA = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
-        Assertions.assertFalse(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpChargedASA));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpChargedASA, true);
-        });
+        Assertions.assertFalse(FunctionalGroupsFinder.checkConstraints(tmpChargedASA));
+        Assertions.assertEquals(0, FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpChargedASA, true).size());
         tmpMoleculeSmiles = "CC(=O)OC1=CC=CC=C1C(=O)O"; //neutral ASA
         IAtomContainer tmpASA = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
-        Assertions.assertTrue(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpASA));
+        Assertions.assertTrue(FunctionalGroupsFinder.checkConstraints(tmpASA));
         Assertions.assertDoesNotThrow(() -> {
             FunctionalGroupsFinder.withGeneralEnvironment().extract(tmpASA, true);
         });
         tmpMoleculeSmiles = "C1=CC(=CC=C1[N+](=O)[O-])O"; //Nitrophenol
         IAtomContainer tmpNitrophenol = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
-        Assertions.assertFalse(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpNitrophenol));
+        Assertions.assertFalse(FunctionalGroupsFinder.checkConstraints(tmpNitrophenol));
         tmpMoleculeSmiles = "CC(=O)O.CC(=O)O.C1=CC(=CC=C1NC(=NC(=NCCCCCCN=C(N)N=C(N)NC2=CC=C(C=C2)Cl)N)N)Cl"; //Chlorhexidine Diacetate
         IAtomContainer tmpChlorhexidineDiacetate = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
-        Assertions.assertFalse(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpChlorhexidineDiacetate));
+        Assertions.assertFalse(FunctionalGroupsFinder.checkConstraints(tmpChlorhexidineDiacetate));
         tmpMoleculeSmiles = "CCO[Si](OCC)(OCC)OCC"; //Tetraethyl Orthosilicate
         IAtomContainer tmpOrthosilicate = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
-        Assertions.assertFalse(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpOrthosilicate));
+        Assertions.assertFalse(FunctionalGroupsFinder.checkConstraints(tmpOrthosilicate));
         tmpMoleculeSmiles = "OCC(CO[*])OC([*])=O"; //CHEBI:598
         IAtomContainer tmpCHEBI598 = tmpSmiPar.parseSmiles(tmpMoleculeSmiles);
-        Assertions.assertFalse(FunctionalGroupsFinder.isValidInputMoleculeIfRestrictionsAreTurnedOn(tmpCHEBI598));
+        Assertions.assertFalse(FunctionalGroupsFinder.checkConstraints(tmpCHEBI598));
     }
     //
     /**

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
@@ -389,6 +389,13 @@ public class FunctionalGroupsFinderTest {
         String[] tmpExpectedFGs = new String[] {"[C]N([H])[H]", "[R]N([R])[R]", "[R]Cl" , "[c]=O", "[R]Cl", "[R]C(=O)OH", "NarR3"};
         this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
     }
+
+    @Test
+    public void testOxirane() throws Exception {
+        String tmpMoleculeSmiles = "CCCCCC1OC1";
+        String[] tmpExpectedFGs = new String[] {"C1OC1"};
+        this.testFind(tmpMoleculeSmiles, tmpExpectedFGs);
+    }
     //
     /**
      * Tests correct functional group identification on an example molecule. Specifically, the extraction of only the marked atoms


### PR DESCRIPTION
Sorry for delay. Like a loose thread on a knitted jumper I started pulling at pieces and more and more things unraveled and more and more I wanted to change. In the end I ended up rewriting it and then trying to make the changes to get it as close as possible to the original implementation. It's a difficult balance as the some of the coding style was quite jarring (lots of variable prefixes: 'tmpBlah', 'aBlah', 'anBlah') and the excessive debugging. 

Overall the code was fine I'm just being picky because I think this functionality is nice/useful so I want it as good as possible - the sugar removal I will be less fussy about. Hopefully I struck a balance between the submitted implementation and the way I would want it. It's not perfect as I'll get to at the end.

You can work through the commits but here is some description/overview.

# API

- Cloning is bad in general and can be used as a bit of a crutch. Ideally unless the point is to modify an input (sugar removal) you should treat the input as immutable and not touch it. If the caller wants to clone the input, let them do it. If they don't - no harm done (providing you didn't modify it). I note CDK does do this in other places but we will change those when possible (it involves breaking the API).
- Likewise the "inputRestrictions" can easily just be an optional call so I removed that boolean as well. 

In both these case it is more self documenting in the calling code to have the user state what they want to do rather than pass 'bool'.

```java
fgf.extract(mol, true, true); // without looking it up it's no obvious what true, true is!

// vs

if (fgf.checkContraints(mol))
  fgf.extract(mol.clone());
```

- I renamed the mode option from DEFAULT, NO_GENERALIZATION, ONLY_MARKED_ATOMS - the two negative modes (NO_ and ONLY_) was a bit hard to work out what did what.
- It is now a linear: NO_ENV, GENERAL_ENV, FULL_ENV.

- I added the ``find(int[], mol)`` API entry point which was essentially already there internally. This is much faster than actually extracting the groups and allows you do generate the following.

```java
int[] groups = new int[mol.getAtomCount()];
fgf.find(groups, mol);
for (IAtom atom : mol.atoms())
  atom.setMapIdx(groups[atom.getIndex()]+1);
String smi = new SmilesGenerator(SmiFlavor.AtomAtomMap).create(mol);
// CC1=CC=CC([NH:1]C2=CC=CC=C2[C:2](=[O:2])[NH:2]C(CC[S+:3](C)[O-:3])[C:4](=[O:4])[NH:4]C(C)C3=CC=C([F:5])C=C3)=C1C
```

You can then display it in CDK depict and generate something similar to what Peter had in the original paper (use 'Color Map' option on the WebApp): 

![image](https://github.com/JonasSchaub/cdk/assets/983232/11928404-973c-4574-a772-024b66c26d80)

This runs method runs pretty fast, ~200ms for 100k ChEMBL molecules on my laptop compared to actually extracting ~800ms.

# Optimisation/Internals

- As suggested on the PR - just using the AtomContainer now can be faster than the adjacency list. In this case I time it about ~29% faster when isolated - e.g. taking out I/O etc.
- The direction we are moving in with CDK is to never have an atom in more than one container at once, it makes much more optimal and easier to use APIs if each atom/bond is 'owned' by a single molecule. It is not more efficient to try and reuse them due to other overheads. Perhaps in future a 'SubsetContainer' would be useful for cases like this but for now the copying is preferred. In this case it is also needed if you want to not modify since the hydrogen count needs to be changed on the atoms.

# Tests

- I added a missing check for carbons in three membered rings ``C1CO1`` etc.
- Bridged hydrogens were not handled correctly, ``B2H6`` test added

# General Style

- Naming is hard but this is a bit of a mouthful: FunctionalGroupFinder.new**FunctionalGroupFinder**GeneralizedMode().extract**FunctionalGroups**(). As a rule of the thumb, methods shouldn't repeat parts of the class name.
- ``obj == null`` is normally preferred to ``Objects.isNull()`` - less to type/read, the later is meant for lambda's ``Objects::isNull``!
- Throwing unchecked exceptions (IllegalArgument/CloneNotSupported) is considered v. bad practice - note the Clone was CDK's AtomContainer fault - it shouldn't have thrown it.
- Likewise using exceptions for control flow is considered not great.
- The ``.isDbg()`` reminds me of Chris's coding style (like in the Structure Diagram Generator) - useful when prototyping but it makes it very had to read the actual code - I removed them 
- Comments < 120-chars, ideally < 80-chars. We do have a code formatting style we run every so often but in this case I wrapped them manually.

# Possible other changes

- I would use canonical SMILES for the tests.. but they're not slow so OK to do the more complicated isomorphism check
- Rather than rely on ``getValency()`` you could compute this as needed when you add on the R groups. This would then mean you don't need to ``perceiveAtomTypes`` on the molecule and in general is more robust. This would allow you to process more molecules without errors (i.g. valency doesn't get set).
- Stereochemistry is not split between the parts, the single electrons/lone pairs are which TBH I probably would have not done. Likewise the Bond 'Stereo' should probably be cleared and not propagated.
- Currently even if you don't need the environment (Environment.NONE) it gets allocated and stored. Also correct me if I'm wrong but I think all the environment carbons get generated even if they are part of the functional group. This then gets fudged later and subtracted out?
- There is a ordering dependance on setting the Carbonyl flag. However since the only case you would not set the flag you would still include that carbon as a functional group it doesn't mater.


Here is an alternative way of doing the generalised environment. It's only marginally more efficient and it would mean we would have a https://en.wikipedia.org/wiki/Ship_of_Theseus situation so I left it. 

```java
    private static final class AtomEnv {
        private int hCount;
        private int rCount;
        private final List<EnvironmentalCType> cTypes = new ArrayList<>();

        private void clear() {
            hCount = 0;
            rCount = 0;
            cTypes.clear();
        }

        @Override
        public String toString() {
            return "Type{" +
                    "hcnt=" + hCount +
                    ", rcnt=" + rCount +
                    ", ctype=" + cTypes +
                    '}';
        }
    }

    private static IBond findCarbonAttachment(IAtom atom, Map<IChemObject,IChemObject> visit) {
        IBond result = null;
        for (IBond bond : atom.bonds()) {
            if (visit.containsKey(bond)) continue;
            if (bond.getOther(atom).getAtomicNumber() == IAtom.C) {
                if (result != null)
                    return null;
                result = bond;
            }
        }
        return result;
    }

    private static boolean determineEnvironment(AtomEnv atomEnv,
                                                IAtom org,
                                                Map<IChemObject,IChemObject> remap,
                                                Environment environment) {
        IAtom cpy = (IAtom)remap.get(org);
        if (cpy == null)
            return false;

        atomEnv.clear();

        if (environment == Environment.NONE) {
            return true;
        } else if (environment == Environment.FULL) {
            atomEnv.hCount = org.getTotalHydrogenCount();
            for (IBond cbond : org.bonds()) {
                if (remap.containsKey(cbond))
                    continue;
                IAtom nbor = cbond.getOther(org);
                if (nbor.getAtomicNumber() != IAtom.C)
                    continue;
                if (nbor.isAromatic()) {
                    if (cbond.isAromatic())
                        atomEnv.cTypes.add(EnvironmentalCType.C_AROMATIC_AROMATIC);
                    else if (cbond.getOrder() == Order.DOUBLE)
                        atomEnv.cTypes.add(EnvironmentalCType.C_AROMATIC_DOUBLE);
                    else
                        atomEnv.cTypes.add(EnvironmentalCType.C_AROMATIC);
                } else {
                    atomEnv.cTypes.add(EnvironmentalCType.C_ALIPHATIC);
                }
            }
            return true;
        }

        // mode == Mode.General

        // 1. environments on carbon atoms are deleted, the only exception are
        //    substituents on carbonyl that are retained (to distinguish between
        //    aldehydes and ketones)
        if (org.getAtomicNumber() == 6 &&
            org.getProperty(CARBONYL_C_MARKER) == null) {
            return false;
        }

        int totalH    = org.getTotalHydrogenCount();
        int explicitH = totalH - org.getImplicitHydrogenCount();
        int degree    = org.getBondCount() - explicitH;
        int size      = cpy.getContainer().getAtomCount();
        IBond cbond = null;

        // 2. all free valences on heteroatoms are filled by the “R atoms” (this
        //    atom may represent hydrogen or carbon) with exception of:
        // 2a. hydrogens on the –OH groups
        if (org.getAtomicNumber() == IAtom.O && degree == 1 && totalH == 1) {
            atomEnv.hCount = totalH;
            totalH = 0;
        }
        // 2b. hydrogens on the simple amines and thiols (i.e. FGs with just
        //     single central N or S atom) are not replaced, this allows to
        //     distinguish secondary and tertiary amines, and thiols and sulfides.
        if ((org.getAtomicNumber() == IAtom.N ||
             org.getAtomicNumber() == IAtom.S) &&
             size == 1 && !org.isAromatic()) {
            atomEnv.hCount = totalH;
            totalH = 0;
        }

        // 3. all remaining environment carbons (on heteroatoms and carbonyls)
        //    are replaced by the “R atoms”; exceptions are environments on
        //    single atomic N or O FGs with one carbon connected, where this
        //    carbon is retained also with its type (aliphatic or aromatic),
        //    this allows to distinguish between amines and anilines, and
        //    alcohols and phenols.
        atomEnv.rCount = totalH;
        for (IBond bond : org.bonds()) {
            if (remap.containsKey(bond))
                continue;
            IAtom nbor = bond.getOther(org);
            if (isPseudoAtom(nbor))
                continue;
            atomEnv.rCount += bond.getOrder().numeric();
        }
        if ((org.getAtomicNumber() == IAtom.O ||
             org.getAtomicNumber() == IAtom.N) &&
             !org.isAromatic() &&
             size == 1 &&
             ((cbond = findCarbonAttachment(org, remap)) != null)) {
            atomEnv.rCount -= cbond.getOrder().numeric();
            // the only possibilities are *-c, *=c, *-C
            if (cbond.getOther(org).isAromatic()) {
                if (cbond.getOrder() == Order.DOUBLE)
                    atomEnv.cTypes.add(EnvironmentalCType.C_AROMATIC_DOUBLE);
                else
                    atomEnv.cTypes.add(EnvironmentalCType.C_AROMATIC);
            } else {
                atomEnv.cTypes.add(EnvironmentalCType.C_ALIPHATIC);
            }
        }
        return true;
    }

    /**
     * Searches the molecule for groups of connected marked atoms and extracts
     * each as a new functional group. The extraction process includes marked
     * atoms' "environments". Connected H's are captured implicitly.
     *
     * @param mol the molecule which contains the functional groups
     * @return a list of all functional groups (including "environments")
     *         extracted from the molecule
     */
    private List<IAtomContainer> extractGroups(IAtomContainer mol, Environment env) {

        // 1) Find/mark the functional groups
        int[] fungrps = new int[mol.getAtomCount()];
        int numFuncGrps = find(fungrps, mol);

        // 2) split the functional groups in to their separate parts in a single
        //    O(N) pass

        // allocate enough atom contains to store our functional groups
        Map<IChemObject,IChemObject> remap = new HashMap<>();

        IAtomContainer[] groups = new IAtomContainer[numFuncGrps+1];
        for (int i=0; i<groups.length; i++)
            groups[i] = mol.getBuilder().newAtomContainer();
        for (IAtom atom : mol.atoms()) {
            int grpNum = fungrps[atom.getIndex()];
            IAtomContainer part = groups[grpNum];
            IAtom newAtom = part.newAtom(atom);
            remap.put(atom, newAtom);
        }
        for (IBond bond : mol.bonds()) {
            IAtom beg = bond.getBegin();
            IAtom end = bond.getEnd();
            int begGrp = fungrps[beg.getIndex()];
            int endGrp = fungrps[end.getIndex()];
            if (begGrp != endGrp)
                continue;
            IAtomContainer part = groups[begGrp];
            remap.put(bond, part.newBond((IAtom) remap.get(beg),
                                         (IAtom) remap.get(end),
                                         bond.getOrder()));
        }
        // JWM: radicals/lone pairs can be split as well but their
        //      info is implicitly captured by the valence of the atoms
        //      the original code did not handle stereochemistry correctly
        //      and splitting molecule like this gets quite tricky

        // 3) expand environments
        AtomEnv atomEnv = new AtomEnv();
        for (IAtom orgAtom : mol.atoms()) {
            IAtom newAtom = (IAtom) remap.get(orgAtom);
            if (newAtom == null)
                continue;
            if (!determineEnvironment(atomEnv, orgAtom, remap, env))
                continue;
            newAtom.setImplicitHydrogenCount(0);
            IAtomContainer part = newAtom.getContainer();
            while (atomEnv.hCount-- > 0) {
                part.newBond(newAtom, part.newAtom(IAtom.H));
            }
            while (atomEnv.rCount-- > 0) {
                part.newBond(newAtom, part.newAtom(IAtom.Wildcard));
            }

            for (EnvironmentalCType ctype : atomEnv.cTypes) {
                IAtom attach = part.newAtom(IAtom.C);
                switch (ctype) {
                    case C_ALIPHATIC:
                        part.newBond(newAtom, attach, Order.SINGLE);
                        break;
                    case C_AROMATIC:
                        attach.setIsAromatic(true);
                        part.newBond(newAtom, attach, Order.SINGLE);
                        break;
                    case C_AROMATIC_AROMATIC:
                        attach.setIsAromatic(true);
                        part.newBond(newAtom, attach, Order.SINGLE).setIsAromatic(true);
                        break;
                    case C_AROMATIC_DOUBLE:
                        attach.setIsAromatic(true);
                        part.newBond(newAtom, attach, Order.DOUBLE);
                        break;
                }
            }
        }

        return Arrays.asList(groups).subList(1,numFuncGrps+1);
    }
```



